### PR TITLE
Reuse transceivers in subscribe path

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
@@ -403,7 +403,7 @@ constructor(
         const val SD_TYPE_ANSWER = "answer"
         const val SD_TYPE_OFFER = "offer"
         const val SD_TYPE_PRANSWER = "pranswer"
-        const val PROTOCOL_VERSION = 2
+        const val PROTOCOL_VERSION = 4
         const val SDK_TYPE = "android"
 
         private fun iceServer(url: String) =

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
@@ -100,6 +100,7 @@ class RemoteParticipant(
         track.name = publication.name
         track.sid = publication.sid
         addTrackPublication(publication)
+        track.start()
 
         // TODO: how does mediatrack send ended event?
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/Track.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/Track.kt
@@ -46,6 +46,10 @@ open class Track(
 
     data class Dimensions(var width: Int, var height: Int)
 
+    open fun start() {
+        rtcTrack.setEnabled(true)
+    }
+
     open fun stop() {
         rtcTrack.setEnabled(false)
     }


### PR DESCRIPTION
Tested it out with the latest js sample client, seems to be working well on protocol 4.