### PR TITLE
Permissions API

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/events/ParticipantEvent.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/events/ParticipantEvent.kt
@@ -1,5 +1,6 @@
 package io.livekit.android.events
 
+import io.livekit.android.room.Room
 import io.livekit.android.room.participant.LocalParticipant
 import io.livekit.android.room.participant.Participant
 import io.livekit.android.room.participant.RemoteParticipant
@@ -106,5 +107,15 @@ sealed class ParticipantEvent(open val participant: Participant) : Event() {
         override val participant: Participant,
         val trackPublication: TrackPublication,
         val streamState: Track.StreamState
+    ) : ParticipantEvent(participant)
+
+
+    /**
+     * A remote track's subscription permissions have changed.
+     */
+    class TrackSubscriptionPermissionChanged(
+        override val participant: RemoteParticipant,
+        val trackPublication: RemoteTrackPublication,
+        val subscriptionAllowed: Boolean
     ) : ParticipantEvent(participant)
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/events/RoomEvent.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/events/RoomEvent.kt
@@ -6,6 +6,7 @@ import io.livekit.android.room.participant.LocalParticipant
 import io.livekit.android.room.participant.Participant
 import io.livekit.android.room.participant.RemoteParticipant
 import io.livekit.android.room.track.LocalTrackPublication
+import io.livekit.android.room.track.RemoteTrackPublication
 import io.livekit.android.room.track.Track
 import io.livekit.android.room.track.TrackPublication
 
@@ -128,6 +129,16 @@ sealed class RoomEvent(val room: Room) : Event() {
         room: Room,
         val trackPublication: TrackPublication,
         val streamState: Track.StreamState
+    ) : RoomEvent(room)
+
+    /**
+     * A remote track's subscription permissions have changed.
+     */
+    class TrackSubscriptionPermissionChanged(
+        room: Room,
+        val participant: RemoteParticipant,
+        val trackPublication: RemoteTrackPublication,
+        val subscriptionAllowed: Boolean
     ) : RoomEvent(room)
 
     /**

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -3,6 +3,7 @@ package io.livekit.android.room
 import android.os.SystemClock
 import io.livekit.android.ConnectOptions
 import io.livekit.android.dagger.InjectionNames
+import io.livekit.android.room.participant.ParticipantTrackPermission
 import io.livekit.android.room.track.TrackException
 import io.livekit.android.room.util.*
 import io.livekit.android.util.CloseableCoroutineScope
@@ -229,6 +230,13 @@ internal constructor(
         }
     }
 
+    fun updateSubscriptionPermissions(
+        allParticipants: Boolean,
+        participantTrackPermissions: List<ParticipantTrackPermission>
+    ) {
+        client.sendUpdateSubscriptionPermissions(allParticipants, participantTrackPermissions)
+    }
+
     fun updateMuteStatus(sid: String, muted: Boolean) {
         client.sendMuteTrack(sid, muted)
     }
@@ -386,6 +394,7 @@ internal constructor(
         fun onUserPacket(packet: LivekitModels.UserPacket, kind: LivekitModels.DataPacket.Kind)
         fun onStreamStateUpdate(streamStates: List<LivekitRtc.StreamStateInfo>)
         fun onSubscribedQualityUpdate(subscribedQualityUpdate: LivekitRtc.SubscribedQualityUpdate)
+        fun onSubscriptionPermissionUpdate(subscriptionPermissionUpdate: LivekitRtc.SubscriptionPermissionUpdate)
     }
 
     companion object {
@@ -529,6 +538,10 @@ internal constructor(
 
     override fun onSubscribedQualityUpdate(subscribedQualityUpdate: LivekitRtc.SubscribedQualityUpdate) {
         listener?.onSubscribedQualityUpdate(subscribedQualityUpdate)
+    }
+
+    override fun onSubscriptionPermissionUpdate(subscriptionPermissionUpdate: LivekitRtc.SubscriptionPermissionUpdate) {
+        listener?.onSubscriptionPermissionUpdate(subscriptionPermissionUpdate)
     }
 
     //--------------------------------- DataChannel.Observer ------------------------------------//

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -226,6 +226,14 @@ constructor(
                             it.streamState
                         )
                     )
+                    is ParticipantEvent.TrackSubscriptionPermissionChanged -> eventBus.postEvent(
+                        RoomEvent.TrackSubscriptionPermissionChanged(
+                            this@Room,
+                            it.participant,
+                            it.trackPublication,
+                            it.subscriptionAllowed
+                        )
+                    )
                 }
             }
         }
@@ -485,21 +493,7 @@ constructor(
 
     override fun onSubscriptionPermissionUpdate(subscriptionPermissionUpdate: LivekitRtc.SubscriptionPermissionUpdate) {
         val participant = getParticipant(subscriptionPermissionUpdate.participantSid) as? RemoteParticipant ?: return
-        val pub = participant.tracks[subscriptionPermissionUpdate.trackSid] as? RemoteTrackPublication ?: return
-
-        if (pub.subscriptionAllowed != subscriptionPermissionUpdate.allowed) {
-            pub.subscriptionAllowed = subscriptionPermissionUpdate.allowed
-
-            // Unsubscribe if become disallowed.
-            if (!pub.subscriptionAllowed && pub.subscribed) {
-                pub.setSubscribed(false)
-            }
-
-            eventBus.postEvent(
-                RoomEvent.TrackSubscriptionPermissionChanged(this, participant, pub, pub.subscriptionAllowed),
-                coroutineScope
-            )
-        }
+        participant.onSubscriptionPermissionUpdate(subscriptionPermissionUpdate)
     }
 
     /**

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -483,6 +483,17 @@ constructor(
         localParticipant.handleSubscribedQualityUpdate(subscribedQualityUpdate)
     }
 
+    override fun onSubscriptionPermissionUpdate(update: LivekitRtc.SubscriptionPermissionUpdate) {
+        val participant = getParticipant(update.participantSid) ?: return
+        val track = participant.tracks[update.trackSid] as? RemoteTrackPublication ?: return
+        track.allowed = update.allowed
+
+        // Unsubscribe if become disallowed.
+        if(!track.allowed && track.subscribed) {
+            track.setSubscribed(false)
+        }
+    }
+
     /**
      * @suppress
      */

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -486,10 +486,10 @@ constructor(
     override fun onSubscriptionPermissionUpdate(update: LivekitRtc.SubscriptionPermissionUpdate) {
         val participant = getParticipant(update.participantSid) ?: return
         val track = participant.tracks[update.trackSid] as? RemoteTrackPublication ?: return
-        track.allowed = update.allowed
+        track.subscriptionAllowed = update.allowed
 
         // Unsubscribe if become disallowed.
-        if(!track.allowed && track.subscribed) {
+        if(!track.subscriptionAllowed && track.subscribed) {
             track.setSubscribed(false)
         }
     }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
@@ -5,6 +5,7 @@ import com.vdurmont.semver4j.Semver
 import io.livekit.android.ConnectOptions
 import io.livekit.android.Version
 import io.livekit.android.dagger.InjectionNames
+import io.livekit.android.room.participant.ParticipantTrackPermission
 import io.livekit.android.room.track.Track
 import io.livekit.android.util.CloseableCoroutineScope
 import io.livekit.android.util.Either
@@ -329,6 +330,21 @@ constructor(
         sendRequest(request)
     }
 
+    fun sendUpdateSubscriptionPermissions(
+        allParticipants: Boolean,
+        participantTrackPermissions: List<ParticipantTrackPermission>
+    ) {
+        val update = LivekitRtc.UpdateSubscriptionPermissions.newBuilder()
+            .setAllParticipants(allParticipants)
+            .addAllTrackPermissions(participantTrackPermissions.map { it.toProto() })
+
+        val request = LivekitRtc.SignalRequest.newBuilder()
+            .setSubscriptionPermissions(update)
+            .build()
+
+        sendRequest(request)
+    }
+
     fun sendLeave() {
         val request = LivekitRtc.SignalRequest.newBuilder()
             .setLeave(LivekitRtc.LeaveRequest.newBuilder().build())
@@ -433,7 +449,7 @@ constructor(
                 listener?.onSubscribedQualityUpdate(response.subscribedQualityUpdate)
             }
             LivekitRtc.SignalResponse.MessageCase.SUBSCRIPTION_PERMISSION_UPDATE -> {
-                // TODO
+                listener?.onSubscriptionPermissionUpdate(response.subscriptionPermissionUpdate)
             }
             LivekitRtc.SignalResponse.MessageCase.MESSAGE_NOT_SET,
             null -> {
@@ -463,6 +479,7 @@ constructor(
         fun onError(error: Throwable)
         fun onStreamStateUpdate(streamStates: List<LivekitRtc.StreamStateInfo>)
         fun onSubscribedQualityUpdate(subscribedQualityUpdate: LivekitRtc.SubscribedQualityUpdate)
+        fun onSubscriptionPermissionUpdate(subscriptionPermissionUpdate: LivekitRtc.SubscriptionPermissionUpdate)
     }
 
     companion object {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -425,8 +425,8 @@ internal constructor(
      * By default, all participants can subscribe. This allows fine-grained control over
      * who is able to subscribe at a participant and track level.
      *
-     * Note: if access is given at a track-level (i.e. [allParticipantsAllowed] and
-     * [ParticipantTrackPermission.allTracksAllowed] is false), any newer published tracks
+     * Note: if access is given at a track-level (i.e. both [allParticipantsAllowed] and
+     * [ParticipantTrackPermission.allTracksAllowed] are false), any newer published tracks
      * will not grant permissions to any participants and will require a subsequent
      * permissions update to allow subscription.
      *

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -419,6 +419,30 @@ internal constructor(
         }
     }
 
+    /**
+     * Control who can subscribe to LocalParticipant's published tracks.
+     *
+     * By default, all participants can subscribe. This allows fine-grained control over
+     * who is able to subscribe at a participant and track level.
+     *
+     * Note: if access is given at a track-level (i.e. [allParticipantsAllowed] and
+     * [ParticipantTrackPermission.allTracksAllowed] is false), any newer published tracks
+     * will not grant permissions to any participants and will require a subsequent
+     * permissions update to allow subscription.
+     *
+     * @param allParticipantsAllowed Allows all participants to subscribe all tracks.
+     *  Takes precedence over [participantTrackPermissions] if set to true.
+     *  By default this is set to true.
+     * @param participantTrackPermissions Full list of individual permissions per
+     *  participant/track. Any omitted participants will not receive any permissions.
+     */
+    fun setTrackSubscriptionPermissions(
+        allParticipantsAllowed: Boolean,
+        participantTrackPermissions: List<ParticipantTrackPermission> = emptyList()
+    ) {
+        engine.updateSubscriptionPermissions(allParticipantsAllowed, participantTrackPermissions)
+    }
+
     fun unpublishTrack(track: Track) {
         val publication = localTrackPublications.firstOrNull { it.track == track }
         if (publication === null) {
@@ -616,4 +640,29 @@ data class AudioTrackPublishOptions(
         base.audioBitrate,
         base.dtx
     )
+}
+
+data class ParticipantTrackPermission(
+    /**
+     * The participant id this permission applies to.
+     */
+    val participantSid: String,
+    /**
+     * If set to true, the target participant can subscribe to all tracks from the local participant.
+     *
+     * Takes precedence over [allowedTrackSids].
+     */
+    val allTracksAllowed: Boolean,
+    /**
+     * The list of track ids that the target participant can subscribe to.
+     */
+    val allowedTrackSids: List<String> = emptyList()
+) {
+    fun toProto(): LivekitRtc.TrackPermission {
+        return LivekitRtc.TrackPermission.newBuilder()
+            .setParticipantSid(participantSid)
+            .setAllTracks(allTracksAllowed)
+            .addAllTrackSids(allowedTrackSids)
+            .build()
+    }
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
@@ -19,8 +19,8 @@ class RemoteParticipant(
     identity: String? = null,
     val signalClient: SignalClient,
     private val ioDispatcher: CoroutineDispatcher,
-    defaultdispatcher: CoroutineDispatcher,
-) : Participant(sid, identity, defaultdispatcher) {
+    defaultDispatcher: CoroutineDispatcher,
+) : Participant(sid, identity, defaultDispatcher) {
     /**
      * @suppress
      */
@@ -28,13 +28,13 @@ class RemoteParticipant(
         info: LivekitModels.ParticipantInfo,
         signalClient: SignalClient,
         ioDispatcher: CoroutineDispatcher,
-        defaultdispatcher: CoroutineDispatcher,
+        defaultDispatcher: CoroutineDispatcher,
     ) : this(
         info.sid,
         info.identity,
         signalClient,
         ioDispatcher,
-        defaultdispatcher
+        defaultDispatcher
     ) {
         updateFromInfo(info)
     }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
@@ -118,10 +118,6 @@ class RemoteParticipant(
             return
         }
 
-        if (!publication.subscriptionAllowed) {
-            return
-        }
-
         val track: Track = when (val kind = mediaTrack.kind()) {
             KIND_AUDIO -> AudioTrack(rtcTrack = mediaTrack as AudioTrack, name = "")
             KIND_VIDEO -> RemoteVideoTrack(

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
@@ -109,7 +109,7 @@ class RemoteTrackPublication(
      * video to reduce bandwidth requirements
      */
     fun setEnabled(enabled: Boolean) {
-        if (isAutoManaged || subscribed != SubscriptionStatus.SUBSCRIBED || enabled == !disabled) {
+        if (isAutoManaged || !subscribed || enabled == !disabled) {
             return
         }
         disabled = !enabled
@@ -124,7 +124,7 @@ class RemoteTrackPublication(
      */
     fun setVideoQuality(quality: LivekitModels.VideoQuality) {
         if (isAutoManaged
-            || subscribed != SubscriptionStatus.SUBSCRIBED
+            || !subscribed
             || quality == videoQuality
             || track !is VideoTrack
         ) {
@@ -140,7 +140,7 @@ class RemoteTrackPublication(
      */
     fun setVideoDimensions(dimensions: Track.Dimensions) {
         if (isAutoManaged
-            || subscribed != SubscriptionStatus.SUBSCRIBED
+            || !subscribed
             || videoDimensions == dimensions
             || track !is VideoTrack
         ) {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
@@ -72,7 +72,7 @@ class RemoteTrackPublication(
 
     override val subscribed: Boolean
         get() {
-            if (unsubscribed) {
+            if (unsubscribed || !subscriptionAllowed) {
                 return false
             }
             return super.subscribed

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
@@ -64,7 +64,7 @@ class RemoteTrackPublication(
     private var videoQuality: LivekitModels.VideoQuality? = LivekitModels.VideoQuality.HIGH
     private var videoDimensions: Track.Dimensions? = null
 
-    var allowed: Boolean = true
+    var subscriptionAllowed: Boolean = true
         internal set
 
     val isAutoManaged: Boolean
@@ -94,10 +94,10 @@ class RemoteTrackPublication(
     /**
      * Subscribe or unsubscribe from this track
      *
-     * If [allowed] is false, subscription will fail.
+     * If [subscriptionAllowed] is false, subscription will fail.
      */
     fun setSubscribed(subscribed: Boolean) {
-        if (subscribed && !allowed) {
+        if (subscribed && !subscriptionAllowed) {
             LKLog.w { "Attempted to subscribe to a disallowed track." }
             return
         }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
@@ -77,6 +77,7 @@ class RemoteTrackPublication(
             }
             return super.subscribed
         }
+
     override var muted: Boolean = false
         set(v) {
             if (field == v) {
@@ -103,6 +104,7 @@ class RemoteTrackPublication(
         }
 
         unsubscribed = !subscribed
+
         val participant = this.participant.get() as? RemoteParticipant ?: return
 
         participant.signalClient.sendUpdateSubscription(sid, !unsubscribed)

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
@@ -4,7 +4,6 @@ import io.livekit.android.dagger.InjectionNames
 import io.livekit.android.events.TrackEvent
 import io.livekit.android.events.collect
 import io.livekit.android.room.participant.RemoteParticipant
-import io.livekit.android.util.LKLog
 import io.livekit.android.util.debounce
 import io.livekit.android.util.invoke
 import kotlinx.coroutines.*
@@ -83,19 +82,10 @@ class RemoteTrackPublication(
 
     /**
      * Subscribe or unsubscribe from this track
-     *
-     * If [subscriptionAllowed] is false, subscription will fail.
      */
     fun setSubscribed(subscribed: Boolean) {
-        if (subscribed && !subscriptionAllowed) {
-            LKLog.w { "Attempted to subscribe to a disallowed track." }
-            return
-        }
-
         unsubscribed = !subscribed
-
         val participant = this.participant.get() as? RemoteParticipant ?: return
-
         participant.signalClient.sendUpdateSubscription(sid, !unsubscribed)
     }
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteTrackPublication.kt
@@ -55,7 +55,20 @@ class RemoteTrackPublication(
     val isAutoManaged: Boolean
         get() = (track as? RemoteVideoTrack)?.autoManageVideo ?: false
 
-    val subscribed: SubscriptionStatus
+    /**
+     * Returns true if track is subscribed, and ready for playback
+     *
+     * @see [subscriptionStatus]
+     */
+    override val subscribed: Boolean
+        get() {
+            if (unsubscribed || !subscriptionAllowed) {
+                return false
+            }
+            return super.subscribed
+        }
+
+    val subscriptionStatus: SubscriptionStatus
         get() {
             return if (!unsubscribed || track == null) {
                 SubscriptionStatus.UNSUBSCRIBED

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/TrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/TrackPublication.kt
@@ -22,6 +22,10 @@ open class TrackPublication(
         private set
     open var muted: Boolean = false
         internal set
+    open val subscribed: Boolean
+        get() {
+            return track != null
+        }
     var simulcasted: Boolean? = null
         internal set
     var dimensions: Track.Dimensions? = null

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/TrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/TrackPublication.kt
@@ -22,10 +22,6 @@ open class TrackPublication(
         private set
     open var muted: Boolean = false
         internal set
-    open val subscribed: Boolean
-        get() {
-            return track != null
-        }
     var simulcasted: Boolean? = null
         internal set
     var dimensions: Track.Dimensions? = null

--- a/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockMediaStream.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockMediaStream.kt
@@ -4,6 +4,9 @@ import org.webrtc.AudioTrack
 import org.webrtc.MediaStream
 import org.webrtc.VideoTrack
 
+fun createMediaStreamId(participantSid: String, trackSid: String) =
+    "${TestData.REMOTE_PARTICIPANT.sid}|${TestData.REMOTE_AUDIO_TRACK.sid}"
+
 class MockMediaStream(private val id: String = "id") : MediaStream(1L) {
 
     override fun addTrack(track: AudioTrack): Boolean {

--- a/livekit-android-sdk/src/test/java/io/livekit/android/mock/dagger/TestCoroutinesModule.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/mock/dagger/TestCoroutinesModule.kt
@@ -9,10 +9,10 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import javax.inject.Named
 
 @Module
-object TestCoroutinesModule {
-
+class TestCoroutinesModule(
     @OptIn(ExperimentalCoroutinesApi::class)
     val coroutineDispatcher: CoroutineDispatcher = TestCoroutineDispatcher()
+) {
 
     @Provides
     @Named(InjectionNames.DISPATCHER_DEFAULT)

--- a/livekit-android-sdk/src/test/java/io/livekit/android/mock/dagger/TestLiveKitComponent.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/mock/dagger/TestLiveKitComponent.kt
@@ -23,6 +23,6 @@ interface TestLiveKitComponent : LiveKitComponent {
 
     @Component.Factory
     interface Factory {
-        fun create(@BindsInstance appContext: Context): TestLiveKitComponent
+        fun create(@BindsInstance appContext: Context, coroutinesModule: TestCoroutinesModule = TestCoroutinesModule()): TestLiveKitComponent
     }
 }

--- a/livekit-android-sdk/src/test/java/io/livekit/android/room/RoomMockE2ETest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/room/RoomMockE2ETest.kt
@@ -256,6 +256,8 @@ class RoomMockE2ETest {
         Assert.assertEquals(true, events[0] is RoomEvent.TrackSubscriptionPermissionChanged)
 
         val event = events[0] as RoomEvent.TrackSubscriptionPermissionChanged
+        Assert.assertEquals(TestData.REMOTE_PARTICIPANT.sid, event.participant.sid)
+        Assert.assertEquals(TestData.REMOTE_AUDIO_TRACK.sid, event.trackPublication.sid)
         Assert.assertEquals(false, event.subscriptionAllowed)
     }
 

--- a/livekit-android-sdk/src/test/java/io/livekit/android/room/SignalClientTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/room/SignalClientTest.kt
@@ -241,6 +241,16 @@ class SignalClientTest {
             }
             build()
         }
+
+        val SUBSCRIPTION_PERMISSION_UPDATE = with(LivekitRtc.SignalResponse.newBuilder()) {
+            subscriptionPermissionUpdate = with(LivekitRtc.SubscriptionPermissionUpdate.newBuilder()) {
+                participantSid = TestData.REMOTE_PARTICIPANT.sid
+                trackSid = TestData.REMOTE_AUDIO_TRACK.sid
+                allowed = false
+                build()
+            }
+            build()
+        }
         val LEAVE = with(LivekitRtc.SignalResponse.newBuilder()) {
             leave = with(leaveBuilder) {
                 build()

--- a/livekit-android-sdk/src/test/java/io/livekit/android/room/participant/RemoteParticipantTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/room/participant/RemoteParticipantTest.kt
@@ -24,7 +24,7 @@ class RemoteParticipantTest {
             "sid",
             signalClient = signalClient,
             ioDispatcher = coroutineRule.dispatcher,
-            defaultdispatcher = coroutineRule.dispatcher,
+            defaultDispatcher = coroutineRule.dispatcher,
         )
     }
 
@@ -38,7 +38,7 @@ class RemoteParticipantTest {
             info,
             signalClient,
             ioDispatcher = coroutineRule.dispatcher,
-            defaultdispatcher = coroutineRule.dispatcher,
+            defaultDispatcher = coroutineRule.dispatcher,
         )
 
         assertEquals(1, participant.tracks.values.size)


### PR DESCRIPTION
Android seems to have some crashes after repeated enabling/disabling of permissions, but that might be a sample app issue rather than SDK issue. I'll look into that separately. JS seems to handle it fine.