### PR TITLE
Fix handling of permissions after resubscribe

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
@@ -131,6 +131,7 @@ class RemoteParticipant(
         }
 
         publication.track = track
+        publication.subscriptionAllowed = true
         track.name = publication.name
         track.sid = publication.sid
         addTrackPublication(publication)


### PR DESCRIPTION
When server sends down a subscription, it's implied permissions are
allowed