### PR TITLE
Don't apply server mute from updateFromInfo

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -464,11 +464,12 @@ internal constructor(
     override fun updateFromInfo(info: LivekitModels.ParticipantInfo) {
         super.updateFromInfo(info)
 
-        // detect tracks that have been muted on the server side, apply those changes
+        // detect tracks that have mute status mismatched on server
         for (ti in info.tracksList) {
             val publication = this.tracks[ti.sid] as? LocalTrackPublication ?: continue
-            if (ti.muted != publication.muted) {
-                publication.muted = ti.muted
+            val localMuted = publication.muted
+            if (ti.muted != localMuted) {
+                engine.updateMuteStatus(sid, localMuted)
             }
         }
     }


### PR DESCRIPTION
Protocol 3 remote mute has server sending explicit mute message for this purpose.

Fixes #146.