### PR TITLE
Add capture observer factory to LocalVideoTrackOptions

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -74,7 +74,7 @@ internal constructor(
             context = context,
             name = name,
             capturer = capturer,
-            options = LocalVideoTrackOptions(),
+            options = options,
             rootEglBase = eglBase,
             trackFactory = videoTrackFactory,
         )
@@ -90,12 +90,12 @@ internal constructor(
         options: LocalVideoTrackOptions = videoTrackCaptureDefaults.copy(),
     ): LocalVideoTrack {
         return LocalVideoTrack.createTrack(
-            peerConnectionFactory,
-            context,
-            name,
-            options,
-            eglBase,
-            videoTrackFactory,
+            peerConnectionFactory = peerConnectionFactory,
+            context = context,
+            name = name,
+            options = options,
+            rootEglBase = eglBase,
+            trackFactory = videoTrackFactory,
         )
     }
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
@@ -11,6 +11,7 @@ import dagger.assisted.AssistedInject
 import io.livekit.android.room.DefaultsManager
 import io.livekit.android.room.track.video.Camera1CapturerWithSize
 import io.livekit.android.room.track.video.Camera2CapturerWithSize
+import io.livekit.android.room.track.video.CapturerObserverDelegate
 import io.livekit.android.room.track.video.VideoCapturerWithSize
 import io.livekit.android.util.LKLog
 import org.webrtc.*
@@ -189,10 +190,12 @@ constructor(
             trackFactory: Factory
         ): LocalVideoTrack {
             val source = peerConnectionFactory.createVideoSource(false)
+            val capturerObservers = listOfNotNull(source.capturerObserver, options.capturerObserverFactory?.invoke())
+
             capturer.initialize(
                 SurfaceTextureHelper.create("VideoCaptureThread", rootEglBase.eglBaseContext),
                 context,
-                source.capturerObserver
+                CapturerObserverDelegate(capturerObservers)
             )
             val track = peerConnectionFactory.createVideoTrack(UUID.randomUUID().toString(), source)
 
@@ -204,6 +207,7 @@ constructor(
                 rtcTrack = track
             )
         }
+
         internal fun createTrack(
             peerConnectionFactory: PeerConnectionFactory,
             context: Context,
@@ -220,11 +224,12 @@ constructor(
             }
 
             val source = peerConnectionFactory.createVideoSource(options.isScreencast)
+            val capturerObservers = listOfNotNull(source.capturerObserver, options.capturerObserverFactory?.invoke())
             val (capturer, newOptions) = createVideoCapturer(context, options) ?: TODO()
             capturer.initialize(
                 SurfaceTextureHelper.create("VideoCaptureThread", rootEglBase.eglBaseContext),
                 context,
-                source.capturerObserver
+                CapturerObserverDelegate(capturerObservers)
             )
             val track = peerConnectionFactory.createVideoTrack(UUID.randomUUID().toString(), source)
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrackOptions.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrackOptions.kt
@@ -1,5 +1,6 @@
 package io.livekit.android.room.track
 
+import org.webrtc.CapturerObserver
 import org.webrtc.RtpParameters
 
 data class LocalVideoTrackOptions(
@@ -10,7 +11,13 @@ data class LocalVideoTrackOptions(
      */
     val deviceId: String? = null,
     val position: CameraPosition? = CameraPosition.FRONT,
-    val captureParams: VideoCaptureParameter = VideoPreset169.QHD.capture
+    val captureParams: VideoCaptureParameter = VideoPreset169.QHD.capture,
+
+    /**
+     * An optional factory to generate a [CapturerObserver] that will be registered
+     * to the video capturer for callbacks.
+     */
+    val capturerObserverFactory: (() -> CapturerObserver)? = null
 )
 
 data class VideoCaptureParameter(

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CapturerObserverDelegate.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CapturerObserverDelegate.kt
@@ -1,0 +1,27 @@
+package io.livekit.android.room.track.video
+
+import org.webrtc.CapturerObserver
+import org.webrtc.VideoFrame
+
+/**
+ * Delivers capturer observer callbacks to multiple observers.
+ *
+ * Observers that aren't WebRTC should avoid blocking the thread with long running operations.
+ */
+class CapturerObserverDelegate(private val observers: Iterable<CapturerObserver>) : CapturerObserver {
+
+    /** Notify if the capturer have been started successfully or not.  */
+    override fun onCapturerStarted(success: Boolean) {
+        observers.forEach { it.onCapturerStarted(success) }
+    }
+
+    /** Notify that the capturer has been stopped.  */
+    override fun onCapturerStopped() {
+        observers.forEach { it.onCapturerStopped() }
+    }
+
+    /** Delivers a captured frame.  */
+    override fun onFrameCaptured(frame: VideoFrame?) {
+        observers.forEach { it.onFrameCaptured(frame) }
+    }
+}


### PR DESCRIPTION
Allows for developers to receive the frames that are being recorded by the video capturer.