### PR TITLE
Fix: Sometimes, the reconnection logic can hang on a flaky internet connection.

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -36,7 +36,6 @@ import io.livekit.android.webrtc.isConnected
 import io.livekit.android.webrtc.isDisconnected
 import io.livekit.android.webrtc.toProtoSessionDescription
 import kotlinx.coroutines.*
-import kotlinx.coroutines.sync.Mutex
 import livekit.LivekitModels
 import livekit.LivekitRtc
 import livekit.LivekitRtc.JoinResponse
@@ -101,7 +100,6 @@ internal constructor(
 
     internal var reconnectType: ReconnectType = ReconnectType.DEFAULT
     private var reconnectingJob: Job? = null
-    private val reconnectingLock = Mutex()
     private var fullReconnectOnNext = false
 
     private val pendingTrackResolvers: MutableMap<String, Continuation<LivekitModels.TrackInfo>> =
@@ -293,6 +291,7 @@ internal constructor(
         if (isClosed) {
             return
         }
+        LKLog.v { "Close - $reason" }
         isClosed = true
         hasPublished = false
         sessionUrl = null
@@ -329,12 +328,14 @@ internal constructor(
     /**
      * reconnect Signal and PeerConnections
      */
+    @Synchronized
     internal fun reconnect() {
-        val didLock = reconnectingLock.tryLock()
-        if (!didLock) {
+        if (reconnectingJob?.isActive == true) {
+            LKLog.d { "Reconnection is already in progress" }
             return
         }
         if (this.isClosed) {
+            LKLog.d { "Skip reconnection - engine is closed" }
             return
         }
         val url = sessionUrl
@@ -449,7 +450,6 @@ internal constructor(
             if (reconnectingJob == job) {
                 reconnectingJob = null
             }
-            reconnectingLock.unlock()
         }
     }
 


### PR DESCRIPTION
The root cause is obvious: `reconnectingLock` was not released when `this.isClosed == true`.
To fix the issue, we can handle the case without using the `reconnectingLock`.