### PR TITLE
Fixed memory leak - LeakCanary leak detection io.livekit.android.rend…

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/compose/VideoRenderer.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/compose/VideoRenderer.kt
@@ -83,7 +83,12 @@ fun VideoRenderer(
 
     DisposableEffect(currentCompositeKeyHash.toString()) {
         onDispose {
-            view?.release()
+            view?.let {
+                it.release()
+                videoTrack?.removeRenderer(it)
+            }
+            view = null
+            boundVideoTrack = null
         }
     }
 


### PR DESCRIPTION
I noticed that sometimes when my app leaves a call, LeakCanary shows that memory leak is detected. After these changes I stopped seeing this message

This PR should fix #324 issue