### PR TITLE
Revert java target to Java 1.8

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,16 @@ subprojects {
             toggleOffOn()
         }
     }
+
+    // From Gradle 8 onwards, Kapt no longer automatically picks up jvmTarget
+    // from normal KotlinOptions. Must be manually set.
+    // JvmToolchain should not be used since it changes the actual JDK used.
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs).configureEach {
+        kotlinOptions {
+            jvmTarget = java_version
+        }
+    }
+
 }
 
 task clean(type: Delete) {

--- a/deps.gradle
+++ b/deps.gradle
@@ -3,7 +3,7 @@ ext {
     compose_version = '1.2.1'
     compose_compiler_version = '1.4.5'
     kotlin_version = '1.8.20'
-    java_version = JavaVersion.VERSION_17
+    java_version = JavaVersion.VERSION_1_8
     dokka_version = '1.5.0'
     androidSdk = [
             compileVersion: 33,

--- a/livekit-lint/build.gradle
+++ b/livekit-lint/build.gradle
@@ -8,6 +8,11 @@ java {
     sourceCompatibility = java_version
     targetCompatibility = java_version
 }
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = java_version
+    }
+}
 
 dependencies {
 


### PR DESCRIPTION
Targeting Java 17 was negatively requiring the downstream consumers to target Java 17 as well.