### PR TITLE
Force webrtc method calls onto a single thread

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
@@ -312,7 +312,6 @@ constructor(
         } ?: SignalingState.CLOSED
     }
 
-
     @OptIn(ExperimentalContracts::class)
     private suspend inline fun <T> launchRTCIfNotClosed(noinline action: suspend () -> T): T? {
         contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
@@ -18,10 +18,10 @@ package io.livekit.android.room
 
 import android.javax.sdp.MediaDescription
 import android.javax.sdp.SdpFactory
+import androidx.annotation.VisibleForTesting
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import io.livekit.android.coroutines.withReentrantLock
 import io.livekit.android.dagger.InjectionNames
 import io.livekit.android.room.util.*
 import io.livekit.android.util.Either
@@ -34,11 +34,12 @@ import io.livekit.android.webrtc.getFmtps
 import io.livekit.android.webrtc.getMsid
 import io.livekit.android.webrtc.getRtps
 import io.livekit.android.webrtc.isConnected
+import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
+import io.livekit.android.webrtc.peerconnection.launchOnRTCThread
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
 import org.webrtc.*
 import org.webrtc.PeerConnection.RTCConfiguration
 import org.webrtc.PeerConnection.SignalingState
@@ -64,7 +65,9 @@ constructor(
     private val sdpFactory: SdpFactory,
 ) {
     private val coroutineScope = CoroutineScope(ioDispatcher + SupervisorJob())
-    private val peerConnection: PeerConnection = connectionFactory.createPeerConnection(
+
+    @VisibleForTesting
+    internal val peerConnection: PeerConnection = connectionFactory.createPeerConnection(
         config,
         pcObserver,
     ) ?: throw IllegalStateException("peer connection creation failed?")
@@ -72,8 +75,6 @@ constructor(
     private var restartingIce: Boolean = false
 
     private var renegotiate = false
-
-    private val mutex = Mutex()
 
     private var trackBitrates = mutableMapOf<TrackBitrateInfoKey, TrackBitrateInfo>()
     private var isClosed = AtomicBoolean(false)
@@ -83,25 +84,23 @@ constructor(
     }
 
     fun addIceCandidate(candidate: IceCandidate) {
-        runBlocking {
-            withNotClosedLock {
-                if (peerConnection.remoteDescription != null && !restartingIce) {
-                    peerConnection.addIceCandidate(candidate)
-                } else {
-                    pendingCandidates.add(candidate)
-                }
+        executeRTCIfNotClosed {
+            if (peerConnection.remoteDescription != null && !restartingIce) {
+                peerConnection.addIceCandidate(candidate)
+            } else {
+                pendingCandidates.add(candidate)
             }
         }
     }
 
     suspend fun <T> withPeerConnection(action: suspend PeerConnection.() -> T): T? {
-        return withNotClosedLock {
+        return launchRTCIfNotClosed {
             action(peerConnection)
         }
     }
 
     suspend fun setRemoteDescription(sd: SessionDescription): Either<Unit, String?> {
-        val result = withNotClosedLock {
+        val result = launchRTCIfNotClosed {
             val result = peerConnection.setRemoteDescription(sd)
             if (result is Either.Left) {
                 pendingCandidates.forEach { pending ->
@@ -137,7 +136,7 @@ constructor(
         var finalSdp: SessionDescription? = null
 
         // TODO: This is a potentially long lock hold. May need to break up.
-        withNotClosedLock {
+        launchRTCIfNotClosed {
             val iceRestart =
                 constraints.findConstraint(MediaConstraintKeys.ICE_RESTART) == MediaConstraintKeys.TRUE
             if (iceRestart) {
@@ -155,7 +154,7 @@ constructor(
                     peerConnection.setRemoteDescription(curSd)
                 } else {
                     renegotiate = true
-                    return@withNotClosedLock
+                    return@launchRTCIfNotClosed
                 }
             }
 
@@ -164,10 +163,13 @@ constructor(
                 is Either.Left -> outcome.value
                 is Either.Right -> {
                     LKLog.d { "error creating offer: ${outcome.value}" }
-                    return@withNotClosedLock
+                    return@launchRTCIfNotClosed
                 }
             }
 
+            if (isClosed()) {
+                return@launchRTCIfNotClosed
+            }
             // munge sdp
             val sdpDescription = sdpFactory.createSessionDescription(sdpOffer.description)
 
@@ -195,11 +197,14 @@ constructor(
 
         LKLog.v { "sdp type: ${sdp.type}\ndescription:\n${sdp.description}" }
         LKLog.v { "munged sdp type: ${mungedSdp.type}\ndescription:\n${mungedSdp.description}" }
-        val mungedResult = if (remote) {
-            peerConnection.setRemoteDescription(mungedSdp)
-        } else {
-            peerConnection.setLocalDescription(mungedSdp)
-        }
+
+        val mungedResult = launchRTCIfNotClosed {
+            if (remote) {
+                peerConnection.setRemoteDescription(mungedSdp)
+            } else {
+                peerConnection.setLocalDescription(mungedSdp)
+            }
+        } ?: Either.Right("PCT closed")
 
         val mungedErrorMessage = when (mungedResult) {
             is Either.Left -> {
@@ -224,11 +229,13 @@ constructor(
         }
         LKLog.w { "error: $mungedErrorMessage" }
 
-        val result = if (remote) {
-            peerConnection.setRemoteDescription(sdp)
-        } else {
-            peerConnection.setLocalDescription(sdp)
-        }
+        val result = launchRTCIfNotClosed {
+            if (remote) {
+                peerConnection.setRemoteDescription(sdp)
+            } else {
+                peerConnection.setLocalDescription(sdp)
+            }
+        } ?: Either.Right("PCT closed")
 
         if (result is Either.Right) {
             val errorMessage = if (result.value.isNullOrBlank()) {
@@ -261,19 +268,15 @@ constructor(
     }
 
     suspend fun close() {
-        withNotClosedLock {
+        launchRTCIfNotClosed {
             isClosed.set(true)
-            peerConnection.close()
-
-            // TODO: properly dispose of peer connection
+            peerConnection.dispose()
         }
     }
 
     fun updateRTCConfig(config: RTCConfiguration) {
-        runBlocking {
-            withNotClosedLock {
-                peerConnection.setConfiguration(config)
-            }
+        executeRTCIfNotClosed {
+            peerConnection.setConfiguration(config)
         }
     }
 
@@ -286,40 +289,57 @@ constructor(
     }
 
     suspend fun isConnected(): Boolean {
-        return withNotClosedLock {
+        return launchRTCIfNotClosed {
             peerConnection.isConnected()
         } ?: false
     }
 
     suspend fun iceConnectionState(): PeerConnection.IceConnectionState {
-        return withNotClosedLock {
+        return launchRTCIfNotClosed {
             peerConnection.iceConnectionState()
         } ?: PeerConnection.IceConnectionState.CLOSED
     }
 
     suspend fun connectionState(): PeerConnection.PeerConnectionState {
-        return withNotClosedLock {
+        return launchRTCIfNotClosed {
             peerConnection.connectionState()
         } ?: PeerConnection.PeerConnectionState.CLOSED
     }
 
     suspend fun signalingState(): SignalingState {
-        return withNotClosedLock {
+        return launchRTCIfNotClosed {
             peerConnection.signalingState()
         } ?: SignalingState.CLOSED
     }
 
+
     @OptIn(ExperimentalContracts::class)
-    private suspend inline fun <T> withNotClosedLock(crossinline action: suspend () -> T): T? {
+    private suspend inline fun <T> launchRTCIfNotClosed(noinline action: suspend () -> T): T? {
         contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
         if (isClosed()) {
             return null
         }
-        return mutex.withReentrantLock {
-            if (isClosed()) {
-                return@withReentrantLock null
+        return launchOnRTCThread {
+            return@launchOnRTCThread if (isClosed()) {
+                null
+            } else {
+                action()
             }
-            return@withReentrantLock action()
+        }
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private fun <T> executeRTCIfNotClosed(action: () -> T): T? {
+        contract { callsInPlace(action, InvocationKind.AT_MOST_ONCE) }
+        if (isClosed()) {
+            return null
+        }
+        return executeOnRTCThread {
+            return@executeOnRTCThread if (isClosed()) {
+                null
+            } else {
+                action()
+            }
         }
     }
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
@@ -34,8 +34,8 @@ import io.livekit.android.webrtc.getFmtps
 import io.livekit.android.webrtc.getMsid
 import io.livekit.android.webrtc.getRtps
 import io.livekit.android.webrtc.isConnected
-import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
-import io.livekit.android.webrtc.peerconnection.launchOnRTCThread
+import io.livekit.android.webrtc.peerconnection.executeBlockingOnRTCThread
+import io.livekit.android.webrtc.peerconnection.launchBlockingOnRTCThread
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -319,8 +319,8 @@ constructor(
         if (isClosed()) {
             return null
         }
-        return launchOnRTCThread {
-            return@launchOnRTCThread if (isClosed()) {
+        return launchBlockingOnRTCThread {
+            return@launchBlockingOnRTCThread if (isClosed()) {
                 null
             } else {
                 action()
@@ -334,8 +334,8 @@ constructor(
         if (isClosed()) {
             return null
         }
-        return executeOnRTCThread {
-            return@executeOnRTCThread if (isClosed()) {
+        return executeBlockingOnRTCThread {
+            return@executeBlockingOnRTCThread if (isClosed()) {
                 null
             } else {
                 action()

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -37,7 +37,7 @@ import io.livekit.android.webrtc.RTCStatsGetter
 import io.livekit.android.webrtc.copy
 import io.livekit.android.webrtc.isConnected
 import io.livekit.android.webrtc.isDisconnected
-import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
+import io.livekit.android.webrtc.peerconnection.executeBlockingOnRTCThread
 import io.livekit.android.webrtc.toProtoSessionDescription
 import kotlinx.coroutines.*
 import livekit.LivekitModels
@@ -318,7 +318,7 @@ internal constructor(
     }
 
     private fun closeResources(reason: String) {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             publisherObserver.connectionChangeListener = null
             subscriberObserver.connectionChangeListener = null
             publisher?.closeBlocking()

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -560,8 +560,8 @@ constructor(
         }
 
         state = State.DISCONNECTED
-        engine.close()
         cleanupRoom()
+        engine.close()
 
         listener?.onDisconnect(this, null)
         listener = null

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/SubscriberTransportObserver.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/SubscriberTransportObserver.kt
@@ -17,6 +17,7 @@
 package io.livekit.android.room
 
 import io.livekit.android.util.LKLog
+import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
 import livekit.LivekitRtc
 import org.webrtc.CandidatePairChangeEvent
 import org.webrtc.DataChannel
@@ -39,14 +40,18 @@ class SubscriberTransportObserver(
     var connectionChangeListener: ((PeerConnection.PeerConnectionState) -> Unit)? = null
 
     override fun onIceCandidate(candidate: IceCandidate) {
-        LKLog.v { "onIceCandidate: $candidate" }
-        client.sendCandidate(candidate, LivekitRtc.SignalTarget.SUBSCRIBER)
+        executeOnRTCThread {
+            LKLog.v { "onIceCandidate: $candidate" }
+            client.sendCandidate(candidate, LivekitRtc.SignalTarget.SUBSCRIBER)
+        }
     }
 
     override fun onAddTrack(receiver: RtpReceiver, streams: Array<out MediaStream>) {
-        val track = receiver.track() ?: return
-        LKLog.v { "onAddTrack: ${track.kind()}, ${track.id()}, ${streams.fold("") { sum, it -> "$sum, $it" }}" }
-        engine.listener?.onAddTrack(receiver, track, streams)
+        executeOnRTCThread {
+            val track = receiver.track() ?: return@executeOnRTCThread
+            LKLog.v { "onAddTrack: ${track.kind()}, ${track.id()}, ${streams.fold("") { sum, it -> "$sum, $it" }}" }
+            engine.listener?.onAddTrack(receiver, track, streams)
+        }
     }
 
     override fun onTrack(transceiver: RtpTransceiver) {
@@ -58,15 +63,19 @@ class SubscriberTransportObserver(
     }
 
     override fun onDataChannel(channel: DataChannel) {
-        dataChannelListener?.invoke(channel)
+        executeOnRTCThread {
+            dataChannelListener?.invoke(channel)
+        }
     }
 
     override fun onStandardizedIceConnectionChange(newState: PeerConnection.IceConnectionState?) {
     }
 
     override fun onConnectionChange(newState: PeerConnection.PeerConnectionState) {
-        LKLog.v { "onConnectionChange new state: $newState" }
-        connectionChangeListener?.invoke(newState)
+        executeOnRTCThread {
+            LKLog.v { "onConnectionChange new state: $newState" }
+            connectionChangeListener?.invoke(newState)
+        }
     }
 
     override fun onSelectedCandidatePairChanged(event: CandidatePairChangeEvent?) {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
@@ -182,7 +182,7 @@ class RemoteParticipant(
         if (track != null) {
             try {
                 track.stop()
-            } catch (e: IllegalStateException) {
+            } catch (e: Exception) {
                 // track may already be disposed, ignore.
             }
             internalListener?.onTrackUnsubscribed(track, publication, this)

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrack.kt
@@ -20,6 +20,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
+import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
 import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.RtpSender
@@ -36,9 +37,9 @@ class LocalAudioTrack(
     mediaTrack: org.webrtc.AudioTrack
 ) : AudioTrack(name, mediaTrack) {
     var enabled: Boolean
-        get() = rtcTrack.enabled()
+        get() = executeOnRTCThread { rtcTrack.enabled() }
         set(value) {
-            rtcTrack.setEnabled(value)
+            executeOnRTCThread { rtcTrack.setEnabled(value) }
         }
 
     internal var transceiver: RtpTransceiver? = null

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrack.kt
@@ -20,7 +20,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
-import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
+import io.livekit.android.webrtc.peerconnection.executeBlockingOnRTCThread
 import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.RtpSender
@@ -37,9 +37,9 @@ class LocalAudioTrack(
     mediaTrack: org.webrtc.AudioTrack
 ) : AudioTrack(name, mediaTrack) {
     var enabled: Boolean
-        get() = executeOnRTCThread { rtcTrack.enabled() }
+        get() = executeBlockingOnRTCThread { rtcTrack.enabled() }
         set(value) {
-            executeOnRTCThread { rtcTrack.setEnabled(value) }
+            executeBlockingOnRTCThread { rtcTrack.setEnabled(value) }
         }
 
     internal var transceiver: RtpTransceiver? = null

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteAudioTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteAudioTrack.kt
@@ -16,6 +16,7 @@
 
 package io.livekit.android.room.track
 
+import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
 import org.webrtc.AudioTrack
 import org.webrtc.AudioTrackSink
 import org.webrtc.RtpReceiver
@@ -23,7 +24,7 @@ import org.webrtc.RtpReceiver
 class RemoteAudioTrack(
     name: String,
     rtcTrack: AudioTrack,
-    internal val receiver: RtpReceiver
+    internal val receiver: RtpReceiver,
 ) : io.livekit.android.room.track.AudioTrack(name, rtcTrack) {
 
     /**
@@ -35,13 +36,17 @@ class RemoteAudioTrack(
      * to use the data after this function returns.
      */
     fun addSink(sink: AudioTrackSink) {
-        rtcTrack.addSink(sink)
+        executeOnRTCThread {
+            rtcTrack.addSink(sink)
+        }
     }
 
     /**
      * Removes a previously added sink.
      */
     fun removeSink(sink: AudioTrackSink) {
-        rtcTrack.removeSink(sink)
+        executeOnRTCThread {
+            rtcTrack.removeSink(sink)
+        }
     }
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteAudioTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/RemoteAudioTrack.kt
@@ -16,7 +16,7 @@
 
 package io.livekit.android.room.track
 
-import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
+import io.livekit.android.webrtc.peerconnection.executeBlockingOnRTCThread
 import org.webrtc.AudioTrack
 import org.webrtc.AudioTrackSink
 import org.webrtc.RtpReceiver
@@ -36,7 +36,7 @@ class RemoteAudioTrack(
      * to use the data after this function returns.
      */
     fun addSink(sink: AudioTrackSink) {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             rtcTrack.addSink(sink)
         }
     }
@@ -45,7 +45,7 @@ class RemoteAudioTrack(
      * Removes a previously added sink.
      */
     fun removeSink(sink: AudioTrackSink) {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             rtcTrack.removeSink(sink)
         }
     }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/Track.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/Track.kt
@@ -21,7 +21,7 @@ import io.livekit.android.events.TrackEvent
 import io.livekit.android.util.flowDelegate
 import io.livekit.android.webrtc.RTCStatsGetter
 import io.livekit.android.webrtc.getStats
-import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
+import io.livekit.android.webrtc.peerconnection.executeBlockingOnRTCThread
 import livekit.LivekitModels
 import livekit.LivekitRtc
 import org.webrtc.MediaStreamTrack
@@ -150,19 +150,19 @@ abstract class Track(
     data class Dimensions(val width: Int, val height: Int)
 
     open fun start() {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             rtcTrack.setEnabled(true)
         }
     }
 
     open fun stop() {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             rtcTrack.setEnabled(false)
         }
     }
 
     open fun dispose() {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             rtcTrack.dispose()
         }
     }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/Track.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/Track.kt
@@ -21,6 +21,7 @@ import io.livekit.android.events.TrackEvent
 import io.livekit.android.util.flowDelegate
 import io.livekit.android.webrtc.RTCStatsGetter
 import io.livekit.android.webrtc.getStats
+import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
 import livekit.LivekitModels
 import livekit.LivekitRtc
 import org.webrtc.MediaStreamTrack
@@ -149,15 +150,21 @@ abstract class Track(
     data class Dimensions(val width: Int, val height: Int)
 
     open fun start() {
-        rtcTrack.setEnabled(true)
+        executeOnRTCThread {
+            rtcTrack.setEnabled(true)
+        }
     }
 
     open fun stop() {
-        rtcTrack.setEnabled(false)
+        executeOnRTCThread {
+            rtcTrack.setEnabled(false)
+        }
     }
 
     open fun dispose() {
-        rtcTrack.dispose()
+        executeOnRTCThread {
+            rtcTrack.dispose()
+        }
     }
 }
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/VideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/VideoTrack.kt
@@ -52,6 +52,5 @@ abstract class VideoTrack(name: String, override val rtcTrack: VideoTrack) :
             }
         }
         super.stop()
-
     }
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/VideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/VideoTrack.kt
@@ -16,7 +16,7 @@
 
 package io.livekit.android.room.track
 
-import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
+import io.livekit.android.webrtc.peerconnection.executeBlockingOnRTCThread
 import org.webrtc.VideoSink
 import org.webrtc.VideoTrack
 
@@ -31,21 +31,21 @@ abstract class VideoTrack(name: String, override val rtcTrack: VideoTrack) :
         }
 
     open fun addRenderer(renderer: VideoSink) {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             sinks.add(renderer)
             rtcTrack.addSink(renderer)
         }
     }
 
     open fun removeRenderer(renderer: VideoSink) {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             rtcTrack.removeSink(renderer)
             sinks.remove(renderer)
         }
     }
 
     override fun stop() {
-        executeOnRTCThread {
+        executeBlockingOnRTCThread {
             for (sink in sinks) {
                 rtcTrack.removeSink(sink)
                 sinks.clear()

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/VideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/VideoTrack.kt
@@ -16,6 +16,7 @@
 
 package io.livekit.android.room.track
 
+import io.livekit.android.webrtc.peerconnection.executeOnRTCThread
 import org.webrtc.VideoSink
 import org.webrtc.VideoTrack
 
@@ -30,20 +31,27 @@ abstract class VideoTrack(name: String, override val rtcTrack: VideoTrack) :
         }
 
     open fun addRenderer(renderer: VideoSink) {
-        sinks.add(renderer)
-        rtcTrack.addSink(renderer)
+        executeOnRTCThread {
+            sinks.add(renderer)
+            rtcTrack.addSink(renderer)
+        }
     }
 
     open fun removeRenderer(renderer: VideoSink) {
-        rtcTrack.removeSink(renderer)
-        sinks.remove(renderer)
+        executeOnRTCThread {
+            rtcTrack.removeSink(renderer)
+            sinks.remove(renderer)
+        }
     }
 
     override fun stop() {
-        for (sink in sinks) {
-            rtcTrack.removeSink(sink)
+        executeOnRTCThread {
+            for (sink in sinks) {
+                rtcTrack.removeSink(sink)
+                sinks.clear()
+            }
         }
-        sinks.clear()
         super.stop()
+
     }
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/util/Either.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/util/Either.kt
@@ -21,6 +21,6 @@ sealed class Either<out A, out B> {
     class Right<out B>(val value: B) : Either<Nothing, B>()
 }
 
-fun <A> Either<A, String?>?.nullSafe(): Either<A, String?>{
+fun <A> Either<A, String?>?.nullSafe(): Either<A, String?> {
     return this ?: Either.Right("null")
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/util/Either.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/util/Either.kt
@@ -20,3 +20,7 @@ sealed class Either<out A, out B> {
     class Left<out A>(val value: A) : Either<A, Nothing>()
     class Right<out B>(val value: B) : Either<Nothing, B>()
 }
+
+fun <A> Either<A, String?>?.nullSafe(): Either<A, String?>{
+    return this ?: Either.Right("null")
+}

--- a/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/PeerConnectionResource.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/PeerConnectionResource.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.livekit.android.webrtc.peerconnection
 
 import org.webrtc.PeerConnection

--- a/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/PeerConnectionResource.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/PeerConnectionResource.kt
@@ -1,0 +1,41 @@
+package io.livekit.android.webrtc.peerconnection
+
+import org.webrtc.PeerConnection
+import org.webrtc.RtpReceiver
+import org.webrtc.RtpSender
+import org.webrtc.RtpTransceiver
+
+/**
+ * Objects obtained through [PeerConnection] are transient,
+ * and should not be kept in memory. Calls to these methods
+ * dispose all existing objects in the tree and refresh with
+ * new updated objects:
+ *
+ * * [PeerConnection.getTransceivers]
+ * * [PeerConnection.getReceivers]
+ * * [PeerConnection.getSenders]
+ *
+ * For this reason, any object gotten through the PeerConnection
+ * should instead be looked up through the PeerConnection as needed.
+ */
+internal abstract class PeerConnectionResource<T>(val parentPeerConnection: PeerConnection) {
+    abstract fun get(): T?
+}
+
+internal class RtpTransceiverResource(parentPeerConnection: PeerConnection, private val senderId: String) : PeerConnectionResource<RtpTransceiver>(parentPeerConnection) {
+    override fun get() = executeOnRTCThread {
+        parentPeerConnection.transceivers.firstOrNull { t -> t.sender.id() == senderId }
+    }
+}
+
+internal class RtpReceiverResource(parentPeerConnection: PeerConnection, private val receiverId: String) : PeerConnectionResource<RtpReceiver>(parentPeerConnection) {
+    override fun get() = executeOnRTCThread {
+        parentPeerConnection.receivers.firstOrNull { r -> r.id() == receiverId }
+    }
+}
+
+internal class RtpSenderResource(parentPeerConnection: PeerConnection, private val senderId: String) : PeerConnectionResource<RtpSender>(parentPeerConnection) {
+    override fun get() = executeOnRTCThread {
+        parentPeerConnection.senders.firstOrNull { s -> s.id() == senderId }
+    }
+}

--- a/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/PeerConnectionResource.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/PeerConnectionResource.kt
@@ -23,19 +23,19 @@ internal abstract class PeerConnectionResource<T>(val parentPeerConnection: Peer
 }
 
 internal class RtpTransceiverResource(parentPeerConnection: PeerConnection, private val senderId: String) : PeerConnectionResource<RtpTransceiver>(parentPeerConnection) {
-    override fun get() = executeOnRTCThread {
+    override fun get() = executeBlockingOnRTCThread {
         parentPeerConnection.transceivers.firstOrNull { t -> t.sender.id() == senderId }
     }
 }
 
 internal class RtpReceiverResource(parentPeerConnection: PeerConnection, private val receiverId: String) : PeerConnectionResource<RtpReceiver>(parentPeerConnection) {
-    override fun get() = executeOnRTCThread {
+    override fun get() = executeBlockingOnRTCThread {
         parentPeerConnection.receivers.firstOrNull { r -> r.id() == receiverId }
     }
 }
 
 internal class RtpSenderResource(parentPeerConnection: PeerConnection, private val senderId: String) : PeerConnectionResource<RtpSender>(parentPeerConnection) {
-    override fun get() = executeOnRTCThread {
+    override fun get() = executeBlockingOnRTCThread {
         parentPeerConnection.senders.firstOrNull { s -> s.id() == senderId }
     }
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/RTCThreadUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/RTCThreadUtils.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.livekit.android.webrtc.peerconnection
 
 import androidx.annotation.VisibleForTesting
@@ -10,19 +26,18 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
 
-
 // Executor thread is started once and is used for all
 // peer connection API calls to ensure new peer connection factory is
 // created on the same thread as previously destroyed factory.
 
-private const val EXECUTOR_THREADNAME_PREFIX = "LK_RTC_THREAD";
+private const val EXECUTOR_THREADNAME_PREFIX = "LK_RTC_THREAD"
 private val threadFactory = object : ThreadFactory {
-    private val idGenerator = AtomicInteger(0);
+    private val idGenerator = AtomicInteger(0)
 
     override fun newThread(r: Runnable): Thread {
-        val thread = Thread(r);
-        thread.name = EXECUTOR_THREADNAME_PREFIX + "_" + idGenerator.incrementAndGet();
-        return thread;
+        val thread = Thread(r)
+        thread.name = EXECUTOR_THREADNAME_PREFIX + "_" + idGenerator.incrementAndGet()
+        return thread
     }
 }
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/RTCThreadUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/RTCThreadUtils.kt
@@ -1,0 +1,58 @@
+package io.livekit.android.webrtc.peerconnection
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+
+// Executor thread is started once and is used for all
+// peer connection API calls to ensure new peer connection factory is
+// created on the same thread as previously destroyed factory.
+
+private const val EXECUTOR_THREADNAME_PREFIX = "LK_RTC_THREAD";
+private val threadFactory = object : ThreadFactory {
+    private val idGenerator = AtomicInteger(0);
+
+    override fun newThread(r: Runnable): Thread {
+        val thread = Thread(r);
+        thread.name = EXECUTOR_THREADNAME_PREFIX + "_" + idGenerator.incrementAndGet();
+        return thread;
+    }
+}
+
+internal val executor = Executors.newSingleThreadExecutor(threadFactory)
+internal val rtcDispatcher = executor.asCoroutineDispatcher()
+
+/**
+ * Execute [action] on the RTC thread. The PeerConnection API
+ * is generally not thread safe, so all actions relating to
+ * peer connection objects should go through the RTC thread.
+ */
+fun <T> executeOnRTCThread(action: () -> T): T {
+    return if (Thread.currentThread().name.startsWith(EXECUTOR_THREADNAME_PREFIX)) {
+        action()
+    } else {
+        executor.submit(action).get()
+    }
+}
+
+
+/**
+ * Launch [action] on the RTC thread. The PeerConnection API
+ * is generally not thread safe, so all actions relating to
+ * peer connection objects should go through the RTC thread.
+ */
+suspend fun <T> launchOnRTCThread(action: suspend () -> T): T = coroutineScope {
+    return@coroutineScope if (Thread.currentThread().name.startsWith(EXECUTOR_THREADNAME_PREFIX)) {
+        action()
+    } else {
+        val result = async(rtcDispatcher) {
+            action()
+        }
+
+        result.await()
+    }
+}

--- a/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/RTCThreadUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/webrtc/peerconnection/RTCThreadUtils.kt
@@ -1,8 +1,11 @@
 package io.livekit.android.webrtc.peerconnection
 
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
@@ -23,8 +26,15 @@ private val threadFactory = object : ThreadFactory {
     }
 }
 
-internal val executor = Executors.newSingleThreadExecutor(threadFactory)
-internal val rtcDispatcher = executor.asCoroutineDispatcher()
+// var only for testing purposes, do not alter!
+private var executor = Executors.newSingleThreadExecutor(threadFactory)
+private var rtcDispatcher: CoroutineDispatcher = executor.asCoroutineDispatcher()
+
+@VisibleForTesting
+internal fun overrideExecutorAndDispatcher(executorService: ExecutorService, dispatcher: CoroutineDispatcher) {
+    executor = executorService
+    rtcDispatcher = dispatcher
+}
 
 /**
  * Execute [action] on the RTC thread. The PeerConnection API

--- a/livekit-android-sdk/src/test/java/io/livekit/android/BaseTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/BaseTest.kt
@@ -16,11 +16,14 @@
 
 package io.livekit.android
 
+import com.google.common.util.concurrent.MoreExecutors
 import io.livekit.android.coroutines.TestCoroutineRule
 import io.livekit.android.util.LoggingRule
+import io.livekit.android.webrtc.peerconnection.overrideExecutorAndDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
 import org.mockito.junit.MockitoJUnit
 
@@ -36,6 +39,15 @@ abstract class BaseTest {
     @get:Rule
     var coroutineRule = TestCoroutineRule()
 
+    @Before
+    fun setupRTCThread() {
+        overrideExecutorAndDispatcher(
+            executorService = MoreExecutors.newDirectExecutorService(),
+            dispatcher = coroutineRule.dispatcher,
+        )
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     fun runTest(testBody: suspend TestScope.() -> Unit) = coroutineRule.scope.runTest(testBody = testBody)
+
 }

--- a/livekit-android-sdk/src/test/java/io/livekit/android/BaseTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/BaseTest.kt
@@ -49,5 +49,4 @@ abstract class BaseTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun runTest(testBody: suspend TestScope.() -> Unit) = coroutineRule.scope.runTest(testBody = testBody)
-
 }

--- a/livekit-android-sdk/src/test/java/io/livekit/android/coroutines/CoroutineDispatcherTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/coroutines/CoroutineDispatcherTest.kt
@@ -1,4 +1,0 @@
-package io.livekit.android.coroutines
-
-class CoroutineDispatcherTest {
-}

--- a/livekit-android-sdk/src/test/java/io/livekit/android/coroutines/CoroutineDispatcherTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/coroutines/CoroutineDispatcherTest.kt
@@ -1,0 +1,4 @@
+package io.livekit.android.coroutines
+
+class CoroutineDispatcherTest {
+}

--- a/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockAudioStreamTrack.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockAudioStreamTrack.kt
@@ -24,6 +24,9 @@ class MockAudioStreamTrack(
     var enabled: Boolean = true,
     var state: State = State.LIVE,
 ) : AudioTrack(1L) {
+
+    var disposed = false
+
     override fun id(): String = id
 
     override fun kind(): String = kind
@@ -40,6 +43,10 @@ class MockAudioStreamTrack(
     }
 
     override fun dispose() {
+        if (disposed) {
+            throw IllegalStateException("already disposed")
+        }
+        disposed = true
     }
 
     override fun setVolume(volume: Double) {

--- a/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockMediaStreamTrack.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockMediaStreamTrack.kt
@@ -24,6 +24,8 @@ class MockMediaStreamTrack(
     var enabled: Boolean = true,
     var state: State = State.LIVE,
 ) : MediaStreamTrack(1L) {
+
+    var disposed = false
     override fun id(): String = id
 
     override fun kind(): String = kind
@@ -40,5 +42,9 @@ class MockMediaStreamTrack(
     }
 
     override fun dispose() {
+        if (disposed) {
+            throw IllegalStateException("already disposed")
+        }
+        disposed = true
     }
 }

--- a/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockPeerConnection.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/mock/MockPeerConnection.kt
@@ -214,7 +214,8 @@ class MockPeerConnection(
                     IceConnectionState.NEW -> PeerConnectionState.NEW
                     IceConnectionState.CHECKING -> PeerConnectionState.CONNECTING
                     IceConnectionState.CONNECTED,
-                    IceConnectionState.COMPLETED -> PeerConnectionState.CONNECTED
+                    IceConnectionState.COMPLETED,
+                    -> PeerConnectionState.CONNECTED
 
                     IceConnectionState.DISCONNECTED -> PeerConnectionState.DISCONNECTED
                     IceConnectionState.FAILED -> PeerConnectionState.FAILED
@@ -242,7 +243,8 @@ class MockPeerConnection(
             IceConnectionState.NEW,
             IceConnectionState.CHECKING,
             IceConnectionState.CONNECTED,
-            IceConnectionState.COMPLETED -> {
+            IceConnectionState.COMPLETED,
+            -> {
                 val currentOrdinal = iceConnectionState.ordinal
                 val newOrdinal = newState.ordinal
 
@@ -258,7 +260,8 @@ class MockPeerConnection(
 
             IceConnectionState.FAILED,
             IceConnectionState.DISCONNECTED,
-            IceConnectionState.CLOSED -> {
+            IceConnectionState.CLOSED,
+            -> {
                 // jump to state directly.
                 iceConnectionState = newState
             }
@@ -278,6 +281,9 @@ class MockPeerConnection(
     override fun dispose() {
         iceConnectionState = IceConnectionState.CLOSED
         closed = true
+
+        transceivers.forEach { t -> t.dispose() }
+        transceivers.clear()
     }
 
     override fun getNativePeerConnection(): Long = 0L

--- a/livekit-android-sdk/src/test/java/io/livekit/android/util/LoggingRule.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/util/LoggingRule.kt
@@ -28,21 +28,24 @@ import timber.log.Timber
  */
 class LoggingRule : TestRule {
 
-    val logTree = object : Timber.DebugTree() {
-        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
-            val priorityChar = when (priority) {
-                Log.VERBOSE -> "v"
-                Log.DEBUG -> "d"
-                Log.INFO -> "i"
-                Log.WARN -> "w"
-                Log.ERROR -> "e"
-                Log.ASSERT -> "a"
-                else -> "?"
-            }
+    companion object {
 
-            println("$priorityChar: $tag: $message")
-            if (t != null) {
-                println(t.toString())
+        val logTree = object : Timber.DebugTree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                val priorityChar = when (priority) {
+                    Log.VERBOSE -> "v"
+                    Log.DEBUG -> "d"
+                    Log.INFO -> "i"
+                    Log.WARN -> "w"
+                    Log.ERROR -> "e"
+                    Log.ASSERT -> "a"
+                    else -> "?"
+                }
+
+                println("$priorityChar: $tag: $message")
+                if (t != null) {
+                    println(t.toString())
+                }
             }
         }
     }


### PR DESCRIPTION
The PeerConnection API is not thread safe, so this can cause issues when interacting with it across threads. This additionally helps with the issue of disposing the PeerConnection, making sure there are no threading issues with multiple disposes across threads.