### PR TITLE
Communication workaround for Android 11+

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/LiveKitOverrides.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/LiveKitOverrides.kt
@@ -104,6 +104,22 @@ class AudioOptions(
      * Not used if [audioDeviceModule] is provided.
      */
     val javaAudioDeviceModuleCustomizer: ((builder: JavaAudioDeviceModule.Builder) -> Unit)? = null,
+
+    /**
+     * On Android 11+, the audio mode will reset itself from [AudioManager.MODE_IN_COMMUNICATION] if
+     * there is no audio playback or capture for 6 seconds (for example when joining a room with
+     * no speakers and the local mic is muted.) This mode reset will cause unexpected
+     * behavior when trying to change the volume, causing it to not properly change the volume.
+     *
+     * We use a workaround by playing a silent audio track to keep the communication mode from
+     * resetting.
+     *
+     * Setting this flag to true will disable the workaround.
+     *
+     * This flag is a no-op when the audio mode is set to anything other than
+     * [AudioManager.MODE_IN_COMMUNICATION].
+     */
+    val disableCommunicationModeWorkaround: Boolean = false,
 )
 
 /**

--- a/livekit-android-sdk/src/main/java/io/livekit/android/audio/CommunicationWorkaround.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/audio/CommunicationWorkaround.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2024 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.android.audio
+
+import android.annotation.SuppressLint
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.livekit.android.dagger.InjectionNames
+import io.livekit.android.util.CloseableCoroutineScope
+import kotlinx.coroutines.MainCoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import java.nio.ByteBuffer
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * @see CommunicationWorkaroundImpl
+ */
+interface CommunicationWorkaround {
+
+    fun start()
+    fun stop()
+    fun onStartPlayout()
+    fun onStopPlayout()
+
+    fun dispose()
+}
+
+class NoopCommunicationWorkaround
+@Inject
+constructor() : CommunicationWorkaround {
+    override fun start() {
+    }
+
+    override fun stop() {
+    }
+
+    override fun onStartPlayout() {
+    }
+
+    override fun onStopPlayout() {
+    }
+
+    override fun dispose() {
+    }
+}
+
+/**
+ * Work around for communication mode resetting after 6 seconds if no audio playback or capture.
+ * Issue only happens on 11+ (version code R).
+ * https://issuetracker.google.com/issues/209493718
+ */
+@Singleton
+@RequiresApi(Build.VERSION_CODES.R)
+class CommunicationWorkaroundImpl
+@Inject
+constructor(
+    @Named(InjectionNames.DISPATCHER_MAIN)
+    dispatcher: MainCoroutineDispatcher,
+) : CommunicationWorkaround {
+
+    private val coroutineScope = CloseableCoroutineScope(dispatcher)
+    private val started = MutableStateFlow(false)
+    private val playoutStopped = MutableStateFlow(true)
+
+    private var audioTrack: AudioTrack? = null
+
+    init {
+        coroutineScope.launch {
+            started.combine(playoutStopped) { a, b -> a to b }
+                .distinctUntilChanged()
+                .collect { (started, playoutStopped) ->
+                    onStateChanged(started, playoutStopped)
+                }
+        }
+    }
+
+    override fun start() {
+        started.value = true
+    }
+
+    override fun stop() {
+        started.value = false
+    }
+
+    override fun onStartPlayout() {
+        playoutStopped.value = false
+    }
+
+    override fun onStopPlayout() {
+        playoutStopped.value = true
+    }
+
+    @SuppressLint("NewApi")
+    private fun onStateChanged(started: Boolean, playoutStopped: Boolean) {
+        if (started && playoutStopped) {
+            startAudioTrackIfNeeded()
+        } else {
+            stopAudioTrackIfNeeded()
+        }
+    }
+
+    @SuppressLint("Range")
+    private fun startAudioTrackIfNeeded() {
+        if (audioTrack != null) {
+            return
+        }
+
+        val sampleRate = 16000
+        val audioFormat = AudioFormat.ENCODING_PCM_16BIT
+        val bytesPerFrame = 1 * getBytesPerSample(audioFormat)
+        val framesPerBuffer: Int = sampleRate / 100 // 10 ms
+        val byteBuffer = ByteBuffer.allocateDirect(bytesPerFrame * framesPerBuffer)
+
+        audioTrack = AudioTrack.Builder()
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(audioFormat)
+                    .setSampleRate(sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build(),
+            )
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .setBufferSizeInBytes(byteBuffer.capacity())
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .setSessionId(AudioManager.AUDIO_SESSION_ID_GENERATE)
+            .build()
+
+        audioTrack?.write(byteBuffer, byteBuffer.remaining(), AudioTrack.WRITE_BLOCKING)
+        audioTrack?.setLoopPoints(0, framesPerBuffer - 1, -1)
+
+        audioTrack?.play()
+    }
+
+    // Reference from Android code, AudioFormat.getBytesPerSample. BitPerSample / 8
+    // Default audio data format is PCM 16 bits per sample.
+    // Guaranteed to be supported by all devices
+    private fun getBytesPerSample(audioFormat: Int): Int {
+        return when (audioFormat) {
+            AudioFormat.ENCODING_PCM_8BIT -> 1
+            AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_IEC61937, AudioFormat.ENCODING_DEFAULT -> 2
+            AudioFormat.ENCODING_PCM_FLOAT -> 4
+            AudioFormat.ENCODING_INVALID -> throw IllegalArgumentException("Bad audio format $audioFormat")
+            else -> throw IllegalArgumentException("Bad audio format $audioFormat")
+        }
+    }
+
+    private fun stopAudioTrackIfNeeded() {
+        audioTrack?.stop()
+        audioTrack?.release()
+        audioTrack = null
+    }
+
+    override fun dispose() {
+        coroutineScope.close()
+        stop()
+        stopAudioTrackIfNeeded()
+    }
+}

--- a/livekit-android-sdk/src/main/java/io/livekit/android/dagger/AudioHandlerModule.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/dagger/AudioHandlerModule.kt
@@ -17,11 +17,17 @@
 package io.livekit.android.dagger
 
 import android.media.AudioAttributes
+import android.media.AudioManager
+import android.os.Build
 import dagger.Module
 import dagger.Provides
 import io.livekit.android.AudioType
 import io.livekit.android.audio.AudioHandler
 import io.livekit.android.audio.AudioSwitchHandler
+import io.livekit.android.audio.CommunicationWorkaround
+import io.livekit.android.audio.CommunicationWorkaroundImpl
+import io.livekit.android.audio.NoopCommunicationWorkaround
+import io.livekit.android.memory.CloseableManager
 import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -60,6 +66,29 @@ internal object AudioHandlerModule {
             audioAttributeContentType = audioOutputType.audioAttributes.contentType
             audioAttributeUsageType = audioOutputType.audioAttributes.usage
             audioStreamType = audioOutputType.audioStreamType
+        }
+    }
+
+    @Provides
+    @Singleton
+    @JvmSuppressWildcards
+    fun communicationWorkaround(
+        @Named(InjectionNames.OVERRIDE_DISABLE_COMMUNICATION_WORKAROUND)
+        disableCommunicationWorkaround: Boolean,
+        audioType: AudioType,
+        closeableManager: CloseableManager,
+        commWorkaroundImplProvider: Provider<CommunicationWorkaroundImpl>,
+    ): CommunicationWorkaround {
+        return if (
+            !disableCommunicationWorkaround &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            audioType.audioMode == AudioManager.MODE_IN_COMMUNICATION
+        ) {
+            commWorkaroundImplProvider.get().apply {
+                closeableManager.registerClosable { this.dispose() }
+            }
+        } else {
+            NoopCommunicationWorkaround()
         }
     }
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/dagger/InjectionNames.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/dagger/InjectionNames.kt
@@ -52,5 +52,6 @@ internal object InjectionNames {
     internal const val OVERRIDE_VIDEO_DECODER_FACTORY = "override_video_decoder_factory"
     internal const val OVERRIDE_AUDIO_HANDLER = "override_audio_handler"
     internal const val OVERRIDE_AUDIO_OUTPUT_TYPE = "override_audio_output_type"
+    internal const val OVERRIDE_DISABLE_COMMUNICATION_WORKAROUND = "override_disable_communication_workaround"
     internal const val OVERRIDE_EGL_BASE = "override_egl_base"
 }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/dagger/OverridesModule.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/dagger/OverridesModule.kt
@@ -62,6 +62,10 @@ internal class OverridesModule(private val overrides: LiveKitOverrides) {
     fun audioOutputType() = overrides.audioOptions?.audioOutputType
 
     @Provides
+    @Named(InjectionNames.OVERRIDE_DISABLE_COMMUNICATION_WORKAROUND)
+    fun disableCommunicationWorkAround() = overrides.audioOptions?.disableCommunicationModeWorkaround ?: false
+
+    @Provides
     @Named(InjectionNames.OVERRIDE_EGL_BASE)
     @Nullable
     fun eglBase() = overrides.eglBase

--- a/livekit-android-sdk/src/main/java/io/livekit/android/dagger/RTCModule.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/dagger/RTCModule.kt
@@ -25,6 +25,7 @@ import androidx.annotation.Nullable
 import dagger.Module
 import dagger.Provides
 import io.livekit.android.LiveKit
+import io.livekit.android.audio.CommunicationWorkaround
 import io.livekit.android.memory.CloseableManager
 import io.livekit.android.util.LKLog
 import io.livekit.android.util.LoggingLevel
@@ -91,6 +92,7 @@ internal object RTCModule {
         audioOutputAttributes: AudioAttributes,
         appContext: Context,
         closeableManager: CloseableManager,
+        communicationWorkaround: CommunicationWorkaround,
     ): AudioDeviceModule {
         if (audioDeviceModuleOverride != null) {
             return audioDeviceModuleOverride
@@ -130,6 +132,7 @@ internal object RTCModule {
                 LKLog.e { "onWebRtcAudioTrackError: $errorMessage" }
             }
         }
+
         val audioRecordStateCallback: JavaAudioDeviceModule.AudioRecordStateCallback = object :
             JavaAudioDeviceModule.AudioRecordStateCallback {
             override fun onWebRtcAudioRecordStart() {
@@ -146,10 +149,12 @@ internal object RTCModule {
             JavaAudioDeviceModule.AudioTrackStateCallback {
             override fun onWebRtcAudioTrackStart() {
                 LKLog.v { "Audio playout starts" }
+                communicationWorkaround.onStartPlayout()
             }
 
             override fun onWebRtcAudioTrackStop() {
                 LKLog.v { "Audio playout stops" }
+                communicationWorkaround.onStopPlayout()
             }
         }
 

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -31,6 +31,7 @@ import io.livekit.android.ConnectOptions
 import io.livekit.android.RoomOptions
 import io.livekit.android.Version
 import io.livekit.android.audio.AudioHandler
+import io.livekit.android.audio.CommunicationWorkaround
 import io.livekit.android.dagger.InjectionNames
 import io.livekit.android.e2ee.E2EEManager
 import io.livekit.android.e2ee.E2EEOptions
@@ -69,6 +70,7 @@ constructor(
     val audioHandler: AudioHandler,
     private val closeableManager: CloseableManager,
     private val e2EEManagerFactory: E2EEManager.Factory,
+    private val communicationWorkaround: CommunicationWorkaround,
 ) : RTCEngine.Listener, ParticipantListener {
 
     private lateinit var coroutineScope: CoroutineScope
@@ -133,8 +135,16 @@ constructor(
     var state: State by flowDelegate(State.DISCONNECTED) { new, old ->
         if (new != old) {
             when (new) {
-                State.CONNECTING -> audioHandler.start()
-                State.DISCONNECTED -> audioHandler.stop()
+                State.CONNECTING -> {
+                    audioHandler.start()
+                    communicationWorkaround.start()
+                }
+
+                State.DISCONNECTED -> {
+                    audioHandler.stop()
+                    communicationWorkaround.stop()
+                }
+
                 else -> {}
             }
         }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/util/HandlerExt.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/util/HandlerExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 LiveKit, Inc.
+ * Copyright 2024 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package io.livekit.android.mock.dagger
+package io.livekit.android.util
 
-import dagger.Binds
-import dagger.Module
-import io.livekit.android.audio.AudioHandler
-import io.livekit.android.audio.CommunicationWorkaround
-import io.livekit.android.audio.NoAudioHandler
-import io.livekit.android.audio.NoopCommunicationWorkaround
+import android.os.Handler
+import android.os.Looper
 
-@Module
-interface TestAudioHandlerModule {
-    @Binds
-    fun audioHandler(audioHandler: NoAudioHandler): AudioHandler
-
-    @Binds
-    fun communicationWorkaround(communicationWorkaround: NoopCommunicationWorkaround): CommunicationWorkaround
+fun Handler.runOrPost(r: Runnable) {
+    if (Looper.myLooper() == this.looper) {
+        r.run()
+    } else {
+        post(r)
+    }
 }

--- a/livekit-android-sdk/src/test/java/io/livekit/android/room/RoomTest.kt
+++ b/livekit-android-sdk/src/test/java/io/livekit/android/room/RoomTest.kt
@@ -23,6 +23,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import io.livekit.android.assert.assertIsClassList
 import io.livekit.android.audio.NoAudioHandler
+import io.livekit.android.audio.NoopCommunicationWorkaround
 import io.livekit.android.coroutines.TestCoroutineRule
 import io.livekit.android.e2ee.E2EEManager
 import io.livekit.android.events.*
@@ -99,6 +100,7 @@ class RoomTest {
             audioHandler = NoAudioHandler(),
             closeableManager = CloseableManager(),
             e2EEManagerFactory = e2EEManagerFactory,
+            communicationWorkaround = NoopCommunicationWorkaround(),
         )
     }
 


### PR DESCRIPTION
Work around for communication mode resetting after 6 seconds if no audio playback or capture, by playing a silent track.
Issue only happens on 11+ (version code R).

More details at https://issuetracker.google.com/issues/209493718

v1 PR at #363