### PR TITLE
add foregroundServiceType for ForegroundService

### DIFF
--- a/sample-app-common/src/main/AndroidManifest.xml
+++ b/sample-app-common/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <uses-permission
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
@@ -12,7 +15,10 @@
         android:maxSdkVersion="30" />
 
     <application>
-        <service android:name="io.livekit.android.sample.service.ForegroundService" />
+        <service
+            android:name="io.livekit.android.sample.service.ForegroundService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
To run the sample app in Android 14, ForegroundServiceType should be specified for foreground services: [Documentation LINK](https://developer.android.com/about/versions/14/changes/fgs-types-required)
