### PR TITLE
Have EventListenable.collect return Nothing

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/events/EventListenable.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/events/EventListenable.kt
@@ -30,6 +30,6 @@ interface EventListenable<out T> {
 /**
  * @see [Flow.collect]
  */
-suspend inline fun <T> EventListenable<T>.collect(crossinline action: suspend (value: T) -> Unit) {
+suspend inline fun <T> EventListenable<T>.collect(crossinline action: suspend (value: T) -> Unit): Nothing {
     events.collect { value -> action(value) }
 }


### PR DESCRIPTION
This indicates to linters that this will never return and can mark any code after it as unreachable.

Fixes #457