### PR TITLE
Fix surface causing null pointer exception on some devices

### DIFF
--- a/.changeset/small-beds-add.md
+++ b/.changeset/small-beds-add.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix surface causing null pointer exception on some devices

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXSession.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXSession.kt
@@ -147,7 +147,9 @@ internal constructor(
 
                 surface = Surface(surfaceTextureHelper.surfaceTexture)
                 surfaceProvider = SurfaceProvider { request ->
-                    surface?.let { request.provideSurface(it, helperExecutor) { } }
+                    surface?.let {
+                        request.provideSurface(it, helperExecutor) { }
+                    } ?: request.willNotProvideSurface()
                 }
 
                 // Set image analysis - camera params

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXSession.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXSession.kt
@@ -147,7 +147,7 @@ internal constructor(
 
                 surface = Surface(surfaceTextureHelper.surfaceTexture)
                 surfaceProvider = SurfaceProvider { request ->
-                    request.provideSurface(surface!!, helperExecutor) { }
+                    surface?.let { request.provideSurface(it, helperExecutor) { } }
                 }
 
                 // Set image analysis - camera params


### PR DESCRIPTION
Steps to reproduce. Turn camera on and off then turn it back on. It crashes with null pointer exception. 