### PR TITLE
Fix NoSuchMethodError when calling CameraXHelper.createCameraProvider without useCases

### DIFF
--- a/livekit-android-camerax/README.md
+++ b/livekit-android-camerax/README.md
@@ -55,14 +55,14 @@ We provide a convenience `ScaleZoomHelper` class that can handle pinch-to-zoom f
 
 ### Taking a high quality picture
 
-This allows you to take a high picture without interrupting the video stream.
+This allows you to take a picture without interrupting the video stream.
 
 ```
 // Pass in the imageCapture use case when creating the camera provider
 val imageCapture = ImageCapture.Builder()
     .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
     .build()
-CameraXHelper.createCameraProvider(lifecycleOwner, arrayOf(imageCapture).let {
+CameraXHelper.createCameraProvider(lifecycleOwner, arrayOf(imageCapture)).let {
     if (it.isSupported(application)) {
         CameraCapturerUtils.registerCameraProvider(it)
 

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
@@ -29,19 +29,6 @@ import io.livekit.android.room.track.video.CameraEventsDispatchHandler
 
 class CameraXHelper {
     companion object {
-
-        /**
-         * Creates a CameraProvider that uses CameraX for its sessions.
-         *
-         * For use with [CameraCapturerUtils.registerCameraProvider].
-         * Remember to unregister the provider when outside the lifecycle
-         * of [lifecycleOwner].
-         *
-         * @param lifecycleOwner The lifecycleOwner which controls the lifecycle transitions of the use cases.
-         */
-        @ExperimentalCamera2Interop
-        fun createCameraProvider(lifecycleOwner: LifecycleOwner) = createCameraProvider(lifecycleOwner, emptyArray())
-
         /**
          * Creates a CameraProvider that uses CameraX for its sessions.
          *
@@ -52,6 +39,7 @@ class CameraXHelper {
          * @param lifecycleOwner The lifecycleOwner which controls the lifecycle transitions of the use cases.
          * @param useCases The use cases to bind to a lifecycle.
          */
+        @JvmOverloads
         @ExperimentalCamera2Interop
         fun createCameraProvider(
             lifecycleOwner: LifecycleOwner,

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
@@ -38,6 +38,18 @@ class CameraXHelper {
          * of [lifecycleOwner].
          *
          * @param lifecycleOwner The lifecycleOwner which controls the lifecycle transitions of the use cases.
+         */
+        @ExperimentalCamera2Interop
+        fun createCameraProvider(lifecycleOwner: LifecycleOwner) = createCameraProvider(lifecycleOwner, emptyArray())
+
+        /**
+         * Creates a CameraProvider that uses CameraX for its sessions.
+         *
+         * For use with [CameraCapturerUtils.registerCameraProvider].
+         * Remember to unregister the provider when outside the lifecycle
+         * of [lifecycleOwner].
+         *
+         * @param lifecycleOwner The lifecycleOwner which controls the lifecycle transitions of the use cases.
          * @param useCases The use cases to bind to a lifecycle.
          */
         @ExperimentalCamera2Interop


### PR DESCRIPTION
This fixes an exception that gets thrown in runtime (for some reason) if you try to call `CameraXHelper.createCameraProvider` without the optional `useCases` argument.

`
FATAL EXCEPTION: main Process: io.livekit.android, PID: 30063 java.lang.NoSuchMethodError: No virtual method createCameraProvider(Landroidx/lifecycle/LifecycleOwner;)Lio/livekit/android/room/track/video/CameraCapturerUtils$CameraProvider; in class Llivekit/org/webrtc/CameraXHelper$Companion; or its super classes
`