### PR TITLE
Add publishDTMF method for Sending DTMF signals to SIP Participant

### DIFF
--- a/.changeset/hungry-peas-bow.md
+++ b/.changeset/hungry-peas-bow.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Add publishDTMF method for Sending DTMF signals to SIP Participant

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -736,28 +736,28 @@ internal constructor(
     }
 
     /**
-        * This suspend function allows you to publish DTMF (Dual-Tone Multi-Frequency)
-        * signals within a LiveKit room. The `publishDTMF` function constructs a
-        * SipDTMF message using the provided code and digit, then encapsulates it
-        * in a DataPacket before sending it via the engine.
-        *
-        * Parameters:
-        *  - code: an integer representing the DTMF signal code
-        *  - digit: the string representing the DTMF digit (e.g., "1", "#", "*")
-    */
-    
+     * This suspend function allows you to publish DTMF (Dual-Tone Multi-Frequency)
+     * signals within a LiveKit room. The `publishDtmf` function constructs a
+     * SipDTMF message using the provided code and digit, then encapsulates it
+     * in a DataPacket before sending it via the engine.
+     *
+     * Parameters:
+     *  - code: an integer representing the DTMF signal code
+     *  - digit: the string representing the DTMF digit (e.g., "1", "#", "*")
+     */
+
     @Suppress("unused")
     suspend fun publishDtmf(
         code: Int,
         digit: String,
     ) {
-        
         val sipDTMF = LivekitModels.SipDTMF.newBuilder().setCode(code)
             .setDigit(digit)
             .build()
 
         val dataPacket = LivekitModels.DataPacket.newBuilder()
             .setSipDtmf(sipDTMF)
+            .setKind(LivekitModels.DataPacket.Kind.RELIABLE)
             .build()
 
         engine.sendData(dataPacket)

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -736,6 +736,43 @@ internal constructor(
     }
 
     /**
+        * This suspend function allows you to publish DTMF (Dual-Tone Multi-Frequency)
+        * signals within a LiveKit room. The `publishDTMF` function constructs a 
+        * SipDTMF message using the provided code and digit, then encapsulates it 
+        * in a DataPacket before sending it via the engine. 
+        * 
+        * Parameters:
+        *  - code: an integer representing the DTMF signal code 
+        *  - digit: the string representing the DTMF digit (e.g., "1", "#", "*")
+        *  - reliability: determines how the data is transmitted 
+        *    (RELIABLE by default, meaning guaranteed delivery)
+        *
+        * Note: If the resulting data packet exceeds RTCEngine.MAX_DATA_PACKET_SIZE,
+        *       an IllegalArgumentException is thrown.
+    */
+    
+    @Suppress("unused")
+    suspend fun publishDTMF(
+        code: Int,
+        digit: String,
+        reliability: DataPublishReliability = DataPublishReliability.RELIABLE,
+    ) {
+        if (data.size > RTCEngine.MAX_DATA_PACKET_SIZE) {
+            throw IllegalArgumentException("cannot publish data larger than " + RTCEngine.MAX_DATA_PACKET_SIZE)
+        }
+
+        val sipDTMF = SipDTMF.newBuilder().setCode(code)
+            .setDigit(digit)
+            .build()
+
+        val dataPacket = DataPacket.newBuilder()
+            .setSipDtmf(sipDTMF)
+            .build()
+
+        engine.sendData(dataPacket)
+    }
+
+    /**
      * @suppress
      */
     @VisibleForTesting

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -737,35 +737,26 @@ internal constructor(
 
     /**
         * This suspend function allows you to publish DTMF (Dual-Tone Multi-Frequency)
-        * signals within a LiveKit room. The `publishDTMF` function constructs a 
-        * SipDTMF message using the provided code and digit, then encapsulates it 
-        * in a DataPacket before sending it via the engine. 
-        * 
-        * Parameters:
-        *  - code: an integer representing the DTMF signal code 
-        *  - digit: the string representing the DTMF digit (e.g., "1", "#", "*")
-        *  - reliability: determines how the data is transmitted 
-        *    (RELIABLE by default, meaning guaranteed delivery)
+        * signals within a LiveKit room. The `publishDTMF` function constructs a
+        * SipDTMF message using the provided code and digit, then encapsulates it
+        * in a DataPacket before sending it via the engine.
         *
-        * Note: If the resulting data packet exceeds RTCEngine.MAX_DATA_PACKET_SIZE,
-        *       an IllegalArgumentException is thrown.
+        * Parameters:
+        *  - code: an integer representing the DTMF signal code
+        *  - digit: the string representing the DTMF digit (e.g., "1", "#", "*")
     */
     
     @Suppress("unused")
-    suspend fun publishDTMF(
+    suspend fun publishDtmf(
         code: Int,
         digit: String,
-        reliability: DataPublishReliability = DataPublishReliability.RELIABLE,
     ) {
-        if (data.size > RTCEngine.MAX_DATA_PACKET_SIZE) {
-            throw IllegalArgumentException("cannot publish data larger than " + RTCEngine.MAX_DATA_PACKET_SIZE)
-        }
-
-        val sipDTMF = SipDTMF.newBuilder().setCode(code)
+        
+        val sipDTMF = LivekitModels.SipDTMF.newBuilder().setCode(code)
             .setDigit(digit)
             .build()
 
-        val dataPacket = DataPacket.newBuilder()
+        val dataPacket = LivekitModels.DataPacket.newBuilder()
             .setSipDtmf(sipDTMF)
             .build()
 


### PR DESCRIPTION
### feat: add suspend function to publish DTMF signals

- Implement `publishDTMF` similar to [localparticipant.publishDtmf](https://github.com/livekit/client-sdk-js/blob/d6d03ee6844ef49edd5d5783e436a94e53a5390c/src/room/participant/LocalParticipant.ts#L1430) in client-sdk-js
- Wrap the SipDTMF in a DataPacket and send it via the engine
- Enforce a maximum data size limit (RTCEngine.MAX_DATA_PACKET_SIZE)