### PR TITLE
Fixes deadlock on publish track

### DIFF
--- a/.changeset/three-glasses-join.md
+++ b/.changeset/three-glasses-join.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixes deadlock on publish track

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -483,7 +483,7 @@ internal constructor(
         }
 
         val trackInfo = try {
-             engine.addTrack(
+            engine.addTrack(
                 cid = cid,
                 name = options.name ?: track.name,
                 kind = track.kind.toProto(),

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -481,13 +481,19 @@ internal constructor(
         val builder = AddTrackRequest.newBuilder().apply {
             this.requestConfig()
         }
-        val trackInfo = engine.addTrack(
-            cid = cid,
-            name = options.name ?: track.name,
-            kind = track.kind.toProto(),
-            stream = options.stream,
-            builder = builder,
-        )
+
+        val trackInfo = try {
+             engine.addTrack(
+                cid = cid,
+                name = options.name ?: track.name,
+                kind = track.kind.toProto(),
+                stream = options.stream,
+                builder = builder,
+            )
+        } catch (e: Exception) {
+            publishListener?.onPublishFailure(TrackException.PublishException("Failed to publish track", e))
+            return null
+        }
 
         if (options is VideoTrackPublishOptions) {
             // server might not support the codec the client has requested, in that case, fallback


### PR DESCRIPTION
During a publish track, if the room is leaved before the the track is published, we can't publish a track anymore. Let's abord the pending publish track on leave event and when the websocket is disconnected