### PR TITLE
Improve track publish failure handling

### DIFF
--- a/.changeset/tender-pears-sell.md
+++ b/.changeset/tender-pears-sell.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Improved handling of track publication failures by introducing a new TrackPublicationFailed event and fixing a broken state issue where the track remained active but inaccessible, causing the microphone or camera to stay on without a published track and leading to unreliable republishing.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/events/ParticipantEvent.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/events/ParticipantEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 LiveKit, Inc.
+ * Copyright 2023-2025 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import io.livekit.android.room.participant.RemoteParticipant
 import io.livekit.android.room.track.LocalTrackPublication
 import io.livekit.android.room.track.RemoteTrackPublication
 import io.livekit.android.room.track.Track
+import io.livekit.android.room.track.TrackException
 import io.livekit.android.room.track.TrackPublication
 import io.livekit.android.room.types.TranscriptionSegment
 
@@ -87,6 +88,15 @@ sealed class ParticipantEvent(open val participant: Participant) : Event() {
      */
     class LocalTrackPublished(override val participant: LocalParticipant, val publication: LocalTrackPublication) :
         ParticipantEvent(participant)
+
+    /**
+     * Error had occurred while publishing a track
+     */
+    class LocalTrackPublicationFailed(
+        override val participant: LocalParticipant,
+        val track: Track,
+        val e: TrackException.PublishException,
+    ) : ParticipantEvent(participant)
 
     /**
      * A [LocalParticipant] has unpublished a track

--- a/livekit-android-sdk/src/main/java/io/livekit/android/events/RoomEvent.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/events/RoomEvent.kt
@@ -27,6 +27,7 @@ import io.livekit.android.room.participant.RemoteParticipant
 import io.livekit.android.room.track.LocalTrackPublication
 import io.livekit.android.room.track.RemoteTrackPublication
 import io.livekit.android.room.track.Track
+import io.livekit.android.room.track.TrackException
 import io.livekit.android.room.track.TrackPublication
 import io.livekit.android.room.types.TranscriptionSegment
 import livekit.LivekitModels
@@ -137,6 +138,17 @@ sealed class RoomEvent(val room: Room) : Event() {
      * not fire for tracks that are already published
      */
     class TrackPublished(room: Room, val publication: TrackPublication, val participant: Participant) : RoomEvent(room)
+
+    /**
+     * Error had occurred while publishing a track, for LocalParticipant only
+     * not fire for tracks that are already published
+     */
+    class TrackPublicationFailed(
+        room: Room,
+        val track: Track,
+        val participant: LocalParticipant,
+        e: TrackException.PublishException,
+    ) : RoomEvent(room)
 
     /**
      * A [Participant] has unpublished a track

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -619,6 +619,15 @@ constructor(
                         ),
                     )
 
+                    is ParticipantEvent.LocalTrackPublicationFailed -> emitWhenConnected(
+                        RoomEvent.TrackPublicationFailed(
+                            room = this@Room,
+                            track = it.track,
+                            participant = it.participant,
+                            e = it.e,
+                        ),
+                    )
+
                     is ParticipantEvent.TrackUnpublished -> emitWhenConnected(
                         RoomEvent.TrackUnpublished(
                             room = this@Room,

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -489,6 +489,7 @@ constructor(
             ensureActive()
             if (options.video) {
                 val videoTrack = localParticipant.getOrCreateDefaultVideoTrack()
+                videoTrack.startCapture()
                 if (!localParticipant.publishVideoTrack(videoTrack)) {
                     videoTrack.stopCapture()
                     videoTrack.stop()

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -479,14 +479,20 @@ constructor(
             ensureActive()
             networkCallbackManager.registerCallback()
             if (options.audio) {
-                val audioTrack = localParticipant.createAudioTrack()
+                val audioTrack = localParticipant.getOrCreateDefaultAudioTrack()
                 audioTrack.prewarm()
-                localParticipant.publishAudioTrack(audioTrack)
+                if (!localParticipant.publishAudioTrack(audioTrack)) {
+                    audioTrack.stop()
+                    audioTrack.stopPrewarm()
+                }
             }
             ensureActive()
             if (options.video) {
-                val videoTrack = localParticipant.createVideoTrack()
-                localParticipant.publishVideoTrack(videoTrack)
+                val videoTrack = localParticipant.getOrCreateDefaultVideoTrack()
+                if (!localParticipant.publishVideoTrack(videoTrack)) {
+                    videoTrack.stopCapture()
+                    videoTrack.stop()
+                }
             }
 
             coroutineScope.launch {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -1534,7 +1534,9 @@ internal constructor(
      * @suppress
      */
     fun cleanup() {
+        defaultAudioTrack?.dispose()
         defaultAudioTrack = null
+        defaultVideoTrack?.dispose()
         defaultVideoTrack = null
         for (pub in trackPublications.values) {
             val track = pub.track

--- a/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
@@ -591,20 +591,21 @@ class LocalParticipantMockE2ETest : MockE2ETest() {
     }
 
     @Test
-    fun publishWithNoResponseCausesException() = runTest {
+    fun publishWithNoResponseReturnFalseWithoutException() = runTest {
         connect()
 
         wsFactory.unregisterSignalRequestHandler(wsFactory.defaultSignalRequestHandler)
         var didThrow = false
+        var success: Boolean? = null
         launch {
             try {
-                room.localParticipant.publishVideoTrack(createLocalTrack())
+                success = room.localParticipant.publishVideoTrack(createLocalTrack())
             } catch (e: TrackException.PublishException) {
                 didThrow = true
             }
         }
 
         coroutineRule.dispatcher.scheduler.advanceUntilIdle()
-        assertTrue(didThrow)
+        assertTrue(!didThrow && success == false)
     }
 }


### PR DESCRIPTION
Improved handling of track publication failures by introducing a new TrackPublicationFailed event and fixing a broken state issue where the track remained active but inaccessible, causing the microphone or camera to stay on without a published track and leading to unreliable republishing.

Initially, I tried stopping and disposing of the track instead of keeping it, but that introduced other issues, such as the track not being effectively published. This seems to be related to the behavior within negotiate(). In the end, keeping the track for reuse proved to be simpler and more reliable.

It fixes a new crash introduced in https://github.com/livekit/client-sdk-android/pull/612
```
io.livekit.android.room.track.TrackException$PublishException: Failed to publish track
    at io.livekit.android.room.track.TrackException.<init>
    at io.livekit.android.room.track.TrackException.<init>
    at io.livekit.android.room.track.TrackException$PublishException.<init>
    at io.livekit.android.room.participant.LocalParticipant.publishTrackImpl$requestAddTrack(LocalParticipant.kt:614)
    at io.livekit.android.room.participant.LocalParticipant.access$publishTrackImpl$requestAddTrack
    at io.livekit.android.room.participant.LocalParticipant$publishTrackImpl$requestAddTrack$1.invokeSuspend(LocalParticipant.kt:0)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:0)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:0)
    at kotlinx.coroutines.CompletionStateKt.toState
    at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:0)
    at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:100)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:0)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:0)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:99)
    at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run
    at Futures$CallbackListener.run(Futures.java:0)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:0)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
```

You can test this by applying this patch : [SimulatePublishTrackFailure.patch](https://github.com/user-attachments/files/19712231/SimulatePublishTrackFailure.patch)
