### PR TITLE
Fixes disconnect issue

### DIFF
--- a/.changeset/good-dancers-jam.md
+++ b/.changeset/good-dancers-jam.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixes disconnect issue

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -1550,10 +1550,6 @@ internal constructor(
      * @suppress
      */
     fun cleanup() {
-        defaultAudioTrack?.dispose()
-        defaultAudioTrack = null
-        defaultVideoTrack?.dispose()
-        defaultVideoTrack = null
         for (pub in trackPublications.values) {
             val track = pub.track
 
@@ -1569,6 +1565,10 @@ internal constructor(
                 }
             }
         }
+        defaultAudioTrack?.dispose()
+        defaultAudioTrack = null
+        defaultVideoTrack?.dispose()
+        defaultVideoTrack = null
     }
 
     /**


### PR DESCRIPTION
If the track has already been disposed, the associated MediaStreamTrack is also disposed, causing unpublishTrack to throw an IllegalStateException ("MediaStreamTrack has been disposed."). To prevent this issue, dispose of the defaultTracks only after the track has been unpublished.