### PR TITLE
Refactor and enable switching between cameras using physical id.

### DIFF
--- a/.changeset/gorgeous-ligers-suffer.md
+++ b/.changeset/gorgeous-ligers-suffer.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix switchCamera not working if the camera id is physical id

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,6 +94,7 @@ mockito-core = { module = "org.mockito:mockito-core", version = "4.11.0" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.1.0" }
 #noinspection GradleDependency
 mockito-inline = { module = "org.mockito:mockito-inline", version = "4.11.0" }
+byte-buddy = { module = "net.bytebuddy:byte-buddy", version = "1.14.3" }
 
 robolectric = { module = "org.robolectric:robolectric", version = "4.14.1" }
 turbine = { module = "app.cash.turbine:turbine", version = "1.0.0" }

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXCapturer.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXCapturer.kt
@@ -23,8 +23,6 @@ import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.Camera
 import androidx.camera.core.UseCase
 import androidx.lifecycle.LifecycleOwner
-import io.livekit.android.room.track.video.CameraCapturerUtils.CameraDeviceInfo
-import io.livekit.android.room.track.video.CameraCapturerUtils.findCamera
 import io.livekit.android.room.track.video.CameraCapturerWithSize
 import io.livekit.android.room.track.video.CameraEventsDispatchHandler
 import io.livekit.android.util.FlowObservable
@@ -36,15 +34,10 @@ import kotlinx.coroutines.flow.StateFlow
 internal class CameraXCapturer(
     private val enumerator: CameraXEnumerator,
     private val lifecycleOwner: LifecycleOwner,
-    private val cameraManager: CameraManager,
-    private var cameraDevice: CameraDeviceInfo,
+    private val cameraName: String?,
     eventsHandler: CameraVideoCapturer.CameraEventsHandler?,
     private val useCases: Array<out UseCase> = emptyArray(),
-) : CameraCapturer(cameraDevice.deviceId, eventsHandler, enumerator) {
-
-    override fun getCameraName(): String? {
-        return cameraDevice.deviceId
-    }
+) : CameraCapturer(cameraName, eventsHandler, enumerator) {
 
     @FlowObservable
     @get:FlowObservable
@@ -95,20 +88,12 @@ internal class CameraXCapturer(
             applicationContext,
             lifecycleOwner,
             surfaceTextureHelper,
-            cameraDevice,
+            cameraName,
             width,
             height,
             framerate,
             useCases,
         )
-    }
-
-    override fun switchCamera(switchEventsHandler: CameraVideoCapturer.CameraSwitchHandler?, cameraName: String?) {
-        val device = enumerator.findCamera(cameraManager, cameraName)
-        if (device == null) return
-
-        cameraDevice = device
-        super.switchCamera(switchEventsHandler, cameraDevice.deviceId)
     }
 }
 

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXCapturer.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXCapturer.kt
@@ -42,6 +42,10 @@ internal class CameraXCapturer(
     private val useCases: Array<out UseCase> = emptyArray(),
 ) : CameraCapturer(cameraDevice.deviceId, eventsHandler, enumerator) {
 
+    override fun getCameraName(): String? {
+        return cameraDevice.deviceId
+    }
+
     @FlowObservable
     @get:FlowObservable
     var currentCamera by flowDelegate<Camera?>(null)
@@ -104,7 +108,7 @@ internal class CameraXCapturer(
         if (device == null) return
 
         cameraDevice = device
-        super.switchCamera(switchEventsHandler, this.cameraName)
+        super.switchCamera(switchEventsHandler, cameraDevice.deviceId)
     }
 }
 

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXCapturer.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXCapturer.kt
@@ -32,9 +32,9 @@ import kotlinx.coroutines.flow.StateFlow
 
 @ExperimentalCamera2Interop
 internal class CameraXCapturer(
-    private val enumerator: CameraXEnumerator,
+    enumerator: CameraXEnumerator,
     private val lifecycleOwner: LifecycleOwner,
-    private val cameraName: String?,
+    cameraName: String?,
     eventsHandler: CameraVideoCapturer.CameraEventsHandler?,
     private val useCases: Array<out UseCase> = emptyArray(),
 ) : CameraCapturer(cameraName, eventsHandler, enumerator) {

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
@@ -20,12 +20,14 @@ import android.content.Context
 import android.graphics.Rect
 import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
 import android.os.Build
 import android.os.Build.VERSION
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.UseCase
 import androidx.lifecycle.LifecycleOwner
+import io.livekit.android.room.track.video.CameraCapturerUtils.findCamera
 
 /**
  * @suppress
@@ -35,14 +37,15 @@ class CameraXEnumerator(
     context: Context,
     private val lifecycleOwner: LifecycleOwner,
     private val useCases: Array<out UseCase> = emptyArray(),
-    var physicalCameraId: String? = null,
+    private val cameraManager: CameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager,
 ) : Camera2Enumerator(context) {
 
     override fun createCapturer(
         deviceName: String?,
         eventsHandler: CameraVideoCapturer.CameraEventsHandler?,
     ): CameraVideoCapturer {
-        return CameraXCapturer(context, lifecycleOwner, deviceName, eventsHandler, useCases, physicalCameraId)
+        val deviceInfo = findCamera(cameraManager!!, deviceName, fallback = true)!!
+        return CameraXCapturer(this, lifecycleOwner, cameraManager!!, deviceInfo, eventsHandler, useCases)
     }
 
     companion object {

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
@@ -57,13 +57,15 @@ class CameraXEnumerator(
     }
 
     override fun isBackFacing(deviceName: String?): Boolean {
-        val cameraDevice = findCamera(cameraManager!!, deviceName)
-        return cameraDevice?.position == CameraPosition.BACK
+        val characteristics = cameraManager!!.getCameraCharacteristics(deviceName!!)
+        val lensFacing = characteristics.get(CameraCharacteristics.LENS_FACING)
+        return lensFacing == CameraCharacteristics.LENS_FACING_BACK
     }
 
     override fun isFrontFacing(deviceName: String?): Boolean {
-        val cameraDevice = findCamera(cameraManager!!, deviceName)
-        return cameraDevice?.position == CameraPosition.FRONT
+        val characteristics = cameraManager!!.getCameraCharacteristics(deviceName!!)
+        val lensFacing = characteristics.get(CameraCharacteristics.LENS_FACING)
+        return lensFacing == CameraCharacteristics.LENS_FACING_FRONT
     }
 
     override fun createCapturer(

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
@@ -27,8 +27,6 @@ import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.UseCase
 import androidx.lifecycle.LifecycleOwner
-import io.livekit.android.room.track.CameraPosition
-import io.livekit.android.room.track.video.CameraCapturerUtils.findCamera
 
 /**
  * @suppress

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.graphics.Rect
 import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCharacteristics
-import android.hardware.camera2.CameraManager
 import android.os.Build
 import android.os.Build.VERSION
 import androidx.camera.camera2.interop.Camera2CameraInfo
@@ -36,10 +35,9 @@ class CameraXEnumerator(
     context: Context,
     private val lifecycleOwner: LifecycleOwner,
     private val useCases: Array<out UseCase> = emptyArray(),
-    private val cameraManager: CameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager,
 ) : Camera2Enumerator(context) {
 
-    override fun getDeviceNames(): Array<out String?>? {
+    override fun getDeviceNames(): Array<out String?> {
         val cm = cameraManager!!
         val availableCameraIds = ArrayList<String>()
         for (id in cm.cameraIdList) {

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXEnumerator.kt
@@ -27,6 +27,8 @@ import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.UseCase
 import androidx.lifecycle.LifecycleOwner
+import io.livekit.android.room.track.CameraPosition
+import io.livekit.android.room.track.video.CameraCapturerUtils.findCamera
 
 /**
  * @suppress
@@ -52,6 +54,16 @@ class CameraXEnumerator(
             }
         }
         return availableCameraIds.toTypedArray()
+    }
+
+    override fun isBackFacing(deviceName: String?): Boolean {
+        val cameraDevice = findCamera(cameraManager!!, deviceName)
+        return cameraDevice?.position == CameraPosition.BACK
+    }
+
+    override fun isFrontFacing(deviceName: String?): Boolean {
+        val cameraDevice = findCamera(cameraManager!!, deviceName)
+        return cameraDevice?.position == CameraPosition.FRONT
     }
 
     override fun createCapturer(

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
@@ -63,15 +63,15 @@ class CameraXHelper {
                 val enumerator = provideEnumerator(context)
                 val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
 
-                val targetDevice = findCamera(cameraManager, options.deviceId, options.position)
-                val targetDeviceName = targetDevice?.physicalId ?: targetDevice?.deviceId
+                val targetDevice = enumerator.findCamera(options.deviceId, options.position)
+                val targetDeviceId = targetDevice?.deviceId
 
-                val targetVideoCapturer = enumerator.createCapturer(targetDeviceName, eventsHandler) as CameraXCapturer
+                val targetVideoCapturer = enumerator.createCapturer(targetDeviceId, eventsHandler) as CameraXCapturer
 
                 return CameraXCapturerWithSize(
                     targetVideoCapturer,
                     cameraManager,
-                    targetDeviceName,
+                    targetDeviceId,
                     eventsHandler,
                 )
             }

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
@@ -18,7 +18,6 @@ package livekit.org.webrtc
 
 import android.content.Context
 import android.hardware.camera2.CameraManager
-import android.os.Build
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.UseCase
 import androidx.lifecycle.Lifecycle
@@ -63,15 +62,10 @@ class CameraXHelper {
             ): VideoCapturer {
                 val enumerator = provideEnumerator(context)
                 val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-                val deviceId = options.deviceId
-                var targetDeviceName: String? = null
-                if (deviceId != null) {
-                    targetDeviceName = findCameraById(cameraManager, deviceId)
-                }
-                if (targetDeviceName == null) {
-                    // Fallback to enumerator.findCamera which can't find camera by physical id but it will choose the closest one.
-                    targetDeviceName = enumerator.findCamera(deviceId, options.position)
-                }
+
+                val targetDevice = enumerator.findCamera(cameraManager, options.deviceId, options.position)
+                val targetDeviceName = targetDevice?.physicalId ?: targetDevice?.deviceId
+
                 val targetVideoCapturer = enumerator.createCapturer(targetDeviceName, eventsHandler) as CameraXCapturer
 
                 return CameraXCapturerWithSize(
@@ -84,23 +78,6 @@ class CameraXHelper {
 
             override fun isSupported(context: Context): Boolean {
                 return Camera2Enumerator.isSupported(context) && lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)
-            }
-
-            private fun findCameraById(cameraManager: CameraManager, deviceId: String): String? {
-                for (id in cameraManager.cameraIdList) {
-                    if (id == deviceId) return id // This means the provided id is logical id.
-
-                    val characteristics = cameraManager.getCameraCharacteristics(id)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        val ids = characteristics.physicalCameraIds
-                        if (ids.contains(deviceId)) {
-                            // This means the provided id is physical id.
-                            enumerator?.physicalCameraId = deviceId
-                            return id // This is its logical id.
-                        }
-                    }
-                }
-                return null
             }
         }
 

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXHelper.kt
@@ -63,7 +63,7 @@ class CameraXHelper {
                 val enumerator = provideEnumerator(context)
                 val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
 
-                val targetDevice = enumerator.findCamera(cameraManager, options.deviceId, options.position)
+                val targetDevice = findCamera(cameraManager, options.deviceId, options.position)
                 val targetDeviceName = targetDevice?.physicalId ?: targetDevice?.deviceId
 
                 val targetVideoCapturer = enumerator.createCapturer(targetDeviceName, eventsHandler) as CameraXCapturer

--- a/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXSession.kt
+++ b/livekit-android-camerax/src/main/java/livekit/org/webrtc/CameraXSession.kt
@@ -107,7 +107,7 @@ internal constructor(
         }
     }
 
-    private val cameraDevice: CameraDeviceInfo
+    private val cameraDevice: CameraDeviceId
         get() {
             val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
             return findCamera(cameraManager, cameraId)
@@ -334,15 +334,15 @@ internal constructor(
         return (cameraOrientation + rotation) % 360
     }
 
-    private data class CameraDeviceInfo(val deviceId: String, val physicalId: String?)
+    private data class CameraDeviceId(val deviceId: String, val physicalId: String?)
 
     private fun findCamera(
         cameraManager: CameraManager,
         deviceId: String,
-    ): CameraDeviceInfo? {
+    ): CameraDeviceId? {
         for (id in cameraManager.cameraIdList) {
             // First check if deviceId is a direct logical camera ID
-            if (id == deviceId) return CameraDeviceInfo(id, null)
+            if (id == deviceId) return CameraDeviceId(id, null)
 
             // Then check if deviceId is a physical camera ID in a logical camera
             if (VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -350,7 +350,7 @@ internal constructor(
 
                 for (physicalId in characteristic.physicalCameraIds) {
                     if (deviceId == physicalId) {
-                        return CameraDeviceInfo(id, physicalId)
+                        return CameraDeviceId(id, physicalId)
                     }
                 }
             }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
@@ -184,7 +184,7 @@ constructor(
         val enumerator = createCameraEnumerator(context)
         val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
         if (deviceId != null || position != null) {
-            targetDevice = enumerator.findCamera(cameraManager, deviceId, position, fallback = false)
+            targetDevice = findCamera(cameraManager, deviceId, position, fallback = false)
         }
 
         if (targetDevice == null) {
@@ -195,7 +195,7 @@ constructor(
             }
             val currentIndex = deviceNames.indexOf(options.deviceId)
             val targetDeviceId = deviceNames[(currentIndex + 1) % deviceNames.size]
-            targetDevice = enumerator.findCamera(cameraManager, targetDeviceId, fallback = false)
+            targetDevice = findCamera(cameraManager, targetDeviceId, fallback = false)
         }
 
         val targetDeviceId = targetDevice?.physicalId ?: targetDevice?.deviceId

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
@@ -19,7 +19,6 @@ package io.livekit.android.room.track
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
-import android.hardware.camera2.CameraManager
 import androidx.core.content.ContextCompat
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
@@ -182,9 +182,8 @@ constructor(
 
         var targetDevice: CameraDeviceInfo? = null
         val enumerator = createCameraEnumerator(context)
-        val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
         if (deviceId != null || position != null) {
-            targetDevice = findCamera(cameraManager, deviceId, position, fallback = false)
+            targetDevice = enumerator.findCamera(deviceId, position, fallback = false)
         }
 
         if (targetDevice == null) {
@@ -195,10 +194,10 @@ constructor(
             }
             val currentIndex = deviceNames.indexOf(options.deviceId)
             val targetDeviceId = deviceNames[(currentIndex + 1) % deviceNames.size]
-            targetDevice = findCamera(cameraManager, targetDeviceId, fallback = false)
+            targetDevice = enumerator.findCamera(targetDeviceId, fallback = false)
         }
 
-        val targetDeviceId = targetDevice?.physicalId ?: targetDevice?.deviceId
+        val targetDeviceId = targetDevice?.deviceId
         fun updateCameraOptions() {
             val newOptions = options.copy(
                 deviceId = targetDeviceId,

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
@@ -102,9 +102,8 @@ object CameraCapturerUtils {
         options: LocalVideoTrackOptions,
     ): Pair<VideoCapturer, LocalVideoTrackOptions>? {
         val cameraEventsDispatchHandler = CameraEventsDispatchHandler()
-        val cameraEnumerator = provider.provideEnumerator(context)
         val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-        val targetDevice = cameraEnumerator.findCamera(cameraManager, options.deviceId, options.position) ?: return null
+        val targetDevice = findCamera(cameraManager, options.deviceId, options.position) ?: return null
         val targetVideoCapturer = provider.provideCapturer(context, options, cameraEventsDispatchHandler)
 
         // back fill any missing information
@@ -135,7 +134,7 @@ object CameraCapturerUtils {
             eventsHandler: CameraEventsDispatchHandler,
         ): VideoCapturer {
             val cm = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-            val targetDevice = enumerator.findCamera(cm, options.deviceId, options.position)
+            val targetDevice = findCamera(cm, options.deviceId, options.position)
             // Cache supported capture formats ahead of time to avoid future camera locks.
             Camera1Helper.getSupportedFormats(Camera1Helper.getCameraId(targetDevice?.deviceId))
             val targetDeviceId = targetDevice?.physicalId ?: targetDevice?.deviceId
@@ -167,7 +166,7 @@ object CameraCapturerUtils {
         ): VideoCapturer {
             val enumerator = provideEnumerator(context)
             val cm = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-            val targetDevice = enumerator.findCamera(cm, options.deviceId, options.position)
+            val targetDevice = findCamera(cm, options.deviceId, options.position)
             val targetDeviceId = targetDevice?.physicalId ?: targetDevice?.deviceId
             val targetVideoCapturer = enumerator.createCapturer(targetDeviceId, eventsHandler)
             return Camera2CapturerWithSize(
@@ -188,7 +187,7 @@ object CameraCapturerUtils {
      * @param position the position of a camera. If null, search based on camera position is skipped. Defaults to null.
      * @param fallback if true, when no camera is found by device id/position search, the first available camera on the list will be returned.
      */
-    fun CameraEnumerator.findCamera(
+    fun findCamera(
         cameraManager: CameraManager,
         deviceId: String? = null,
         position: CameraPosition? = null,
@@ -233,7 +232,7 @@ object CameraCapturerUtils {
      * @param predicate with deviceId and position, return true if camera is found
      * @return [CameraDeviceInfo] with camera details or null if not found
      */
-    fun CameraEnumerator.findCamera(
+    fun findCamera(
         cameraManager: CameraManager,
         predicate: (deviceId: String, position: CameraPosition?) -> Boolean,
     ): CameraDeviceInfo? {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
@@ -230,8 +230,8 @@ object CameraCapturerUtils {
      * the logical camera info with the physical ID relationship.
      *
      * @param cameraManager The system camera manager
-     * @param predicate
-     * @return PhysicalCameraInfo with camera details or null if not found
+     * @param predicate with deviceId and position, return true if camera is found
+     * @return [CameraDeviceInfo] with camera details or null if not found
      */
     fun CameraEnumerator.findCamera(
         cameraManager: CameraManager,

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
@@ -197,21 +197,21 @@ object CameraCapturerUtils {
         var targetDeviceName: CameraDeviceInfo? = null
         // Prioritize search by deviceId first
         if (deviceId != null) {
-            targetDeviceName = findCamera(cameraManager) { id, pos ->
+            targetDeviceName = findCamera(cameraManager) { id, _ ->
                 id == deviceId
             }
         }
 
         // Search by camera position
         if (targetDeviceName == null && position != null) {
-            targetDeviceName = findCamera(cameraManager) { id, pos ->
+            targetDeviceName = findCamera(cameraManager) { _, pos ->
                 pos == position
             }
         }
 
         // Fall back by choosing first available camera.
         if (targetDeviceName == null && fallback) {
-            targetDeviceName = findCamera(cameraManager) { id, pos -> true }
+            targetDeviceName = findCamera(cameraManager) { _, _ -> true }
         }
 
         if (targetDeviceName == null) {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
@@ -217,9 +217,13 @@ object CameraCapturerUtils {
         predicate: (deviceId: String, position: CameraPosition?) -> Boolean,
     ): CameraDeviceInfo? {
         for (id in deviceNames) {
-            val position = if (isFrontFacing(id)) CameraPosition.FRONT
-            else if (isBackFacing(id)) CameraPosition.BACK
-            else null
+            val position = if (isFrontFacing(id)) {
+                CameraPosition.FRONT
+            } else if (isBackFacing(id)) {
+                CameraPosition.BACK
+            } else {
+                null
+            }
 
             // First check if deviceId is a direct logical camera ID
             if (predicate(id, position)) return CameraDeviceInfo(id, position)

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/video/CameraCapturerUtils.kt
@@ -70,9 +70,9 @@ object CameraCapturerUtils {
      * Picks CameraProvider of highest available version that is supported on device
      */
     private fun getCameraProvider(context: Context): CameraProvider {
-        return cameraProviders.sortedByDescending { it.cameraVersion }.first {
-            it.isSupported(context)
-        }
+        return cameraProviders
+            .sortedByDescending { it.cameraVersion }
+            .first { it.isSupported(context) }
     }
 
     /**
@@ -225,8 +225,9 @@ object CameraCapturerUtils {
                 null
             }
 
-            // First check if deviceId is a direct logical camera ID
-            if (predicate(id, position)) return CameraDeviceInfo(id, position)
+            if (predicate(id, position)) {
+                return CameraDeviceInfo(id, position)
+            }
         }
         return null
     }

--- a/livekit-android-test/build.gradle
+++ b/livekit-android-test/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     implementation libs.androidx.test.core
     implementation libs.coroutines.test
     implementation libs.dagger.lib
+    implementation libs.byte.buddy
     kapt libs.dagger.compiler
 
     testImplementation libs.junit


### PR DESCRIPTION
This PR is mainly to make `switchCamera` api support `deviceId` that is physical. The previous PR #668 supports it only during initialization. 