### PR TITLE
Avoid a crash on reconnection when a track is disposed

### DIFF
--- a/.changeset/young-scissors-sleep.md
+++ b/.changeset/young-scissors-sleep.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Avoid a crash on reconnection when a track is disposed

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -612,9 +612,15 @@ internal constructor(
 
         if (engine.connectionState == ConnectionState.DISCONNECTED) {
             onPublishFailure(TrackException.PublishException("Not connected!"))
+            return null
         }
 
-        val cid = track.rtcTrack.id()
+        val cid = try {
+            track.rtcTrack.id()
+        } catch (e: Exception) {
+            onPublishFailure(TrackException.PublishException("Failed to get track id", e))
+            return null
+        }
 
         // For fast publish, we can negotiate PC and request add track at the same time
         suspend fun negotiate() {


### PR DESCRIPTION
A crash sometimes occurs during track republication, likely due to a race condition. Much like the connection state is also checked, let's simply trigger `onPublishFailure` and return false.

Crash Stack Trace:
```
java.lang.IllegalStateException: MediaStreamTrack has been disposed.
    at livekit.org.webrtc.MediaStreamTrack.checkMediaStreamTrackExists(MediaStreamTrack.java:0)
    at livekit.org.webrtc.MediaStreamTrack.checkMediaStreamTrackExists(MediaStreamTrack.java:120)
    at livekit.org.webrtc.MediaStreamTrack.id(MediaStreamTrack.java:0)
    at io.livekit.android.room.participant.LocalParticipant.publishTrackImpl(LocalParticipant.kt:612)
    at io.livekit.android.room.participant.LocalParticipant.publishAudioTrack(LocalParticipant.kt:445)
    at io.livekit.android.room.participant.LocalParticipant.republishTracks$_LiveKit_Kotlin_kt(LocalParticipant.kt:1515)
    at io.livekit.android.room.Room.onPostReconnect
    at io.livekit.android.room.RTCEngine$reconnect$job$1.invokeSuspend(RTCEngine.kt:608)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:0)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:0)
    at kotlinx.coroutines.CompletionStateKt.toState
    at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:0)
    at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:100)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:0)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:0)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
    at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(Futures.java:113)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:0)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
```