### PR TITLE
Fix IllegalStateException when switchCamera of localVideoTrack

### DIFF
--- a/.changeset/cool-numbers-perform.md
+++ b/.changeset/cool-numbers-perform.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix IllegalStateException when switchCamera of localVideoTrack

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
@@ -256,7 +256,10 @@ constructor(
     /**
      * Restart a track with new options.
      */
-    fun restartTrack(options: LocalVideoTrackOptions = defaultsManager.videoTrackCaptureDefaults.copy()) {
+    fun restartTrack(
+        options: LocalVideoTrackOptions = defaultsManager.videoTrackCaptureDefaults.copy(),
+        videoProcessor: VideoProcessor? = null
+    ) {
         if (isDisposed) {
             LKLog.e { "Attempting to restart track that was already disposed, aborting." }
             return
@@ -290,6 +293,7 @@ constructor(
             options,
             eglBase,
             trackFactory,
+            videoProcessor
         )
 
         // migrate video sinks to the new track

--- a/livekit-android-track-processors/src/main/java/io/livekit/android/track/processing/video/VirtualBackgroundVideoProcessor.kt
+++ b/livekit-android-track-processors/src/main/java/io/livekit/android/track/processing/video/VirtualBackgroundVideoProcessor.kt
@@ -137,6 +137,7 @@ class VirtualBackgroundVideoProcessor(private val eglBase: EglBase, dispatcher: 
 
     override fun onCapturerStarted(started: Boolean) {
         if (started) {
+            surfaceTextureHelper.stopListening()
             surfaceTextureHelper.startListening { frame ->
                 targetSink?.onFrame(frame)
             }


### PR DESCRIPTION
Added calling surfaceTextureHelper.stopListening() inside onCapturerStarted to prevent crush when switchCamera in LocalVideoTrack.
Added videoProcessor param into LocalVideoTrack.restartTrack to keep videoProcessor when restart the track.