### PR TITLE
Fixed ProGuard rules to keep JniInit class for WebRTC native registration (#735)

### DIFF
--- a/.changeset/fix-proguard-jni-zero.md
+++ b/.changeset/fix-proguard-jni-zero.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed ProGuard rules to keep JniInit class for WebRTC native registration (#735)

--- a/livekit-android-sdk/consumer-rules.pro
+++ b/livekit-android-sdk/consumer-rules.pro
@@ -24,6 +24,12 @@
 #########################################
 -keep class livekit.org.webrtc.** { *; }
 
+# JNI Zero initialization (required for WebRTC native method registration)
+-keep class livekit.org.jni_zero.JniInit {
+    # Keep the init method un-obfuscated for native code callback
+    private static java.lang.Object[] init();
+}
+
 # NIST sdp parser
 #########################################
 -keep class android.gov.nist.** { *; }


### PR DESCRIPTION
Fixes https://github.4psa.me/Hubgets/platform/issues/95017 