### PR TITLE
#721 Fix publisher negotiation race condition causing ICE timeouts

### DIFF
--- a/.changeset/fix-publisher-negotiation-race.md
+++ b/.changeset/fix-publisher-negotiation-race.md
@@ -1,0 +1,6 @@
+---
+"client-sdk-android": patch
+---
+
+#721 Fixed publisher negotiation race condition causing ICE timeouts.
+

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -205,6 +205,12 @@ internal constructor(
      */
     private var configurationLock = Mutex()
 
+    /**
+     * Prevents concurrent publisher negotiations which can cause ICE gathering
+     * race conditions and connection failures.
+     */
+    private val negotiatePublisherMutex = Mutex()
+
     init {
         client.listener = this
     }
@@ -668,7 +674,15 @@ internal constructor(
         hasPublished = true
 
         coroutineScope.launch {
-            publisher?.negotiate?.invoke(getPublisherOfferConstraints())
+            if (negotiatePublisherMutex.tryLock()) {
+                try {
+                    publisher?.negotiate?.invoke(getPublisherOfferConstraints())
+                } finally {
+                    negotiatePublisherMutex.unlock()
+                }
+            } else {
+                LKLog.v { "negotiatePublisher: skipping, negotiation already in progress" }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a race condition in `negotiatePublisher()` that causes ICE gathering failures and connection timeouts when sending data messages immediately after connecting to a room.

## Issue

Fixes https://github.com/livekit/client-sdk-android/issues/721

## Root Cause Analysis

The detailed analysis is in this comment: https://github.com/livekit/client-sdk-android/issues/721#issuecomment-3470564603

### TL;DR

When the server responds with both `subscriberPrimary=true` **and** `fastPublish=true`, two concurrent calls to `negotiatePublisher()` occur:

1. From `RTCEngine.join()` at connection time (when `fastPublish=true`)
2. From `ensurePublisherConnected()` when sending the first data message

The existing debounce mechanism fails with concurrent coroutines due to non-atomic read-modify-write operations on the shared `debounceJob` variable. This results in:
- Multiple parallel SDP offer/answer exchanges
- Conflicting ICE gathering sessions
- Publisher ICE state transitions: DISCONNECTED → FAILED
- Connection timeout after 20 seconds

## The Fix

Added a `Mutex` to serialize `negotiatePublisher()` calls using `tryLock()`:
- First call acquires the lock and runs negotiation
- Second call detects the lock is held and returns immediately (no-op)
- Only one negotiation runs at a time
- No conflicting ICE gathering
- Publisher connects reliably

## Testing

This fix has been tested in production with a VoIP application handling incoming calls that:
1. Connect to LiveKit room with `subscriberPrimary=true`
2. Immediately send "RINGING" data message
3. Send "ANSWER" data message when user answers

Before: ~20% failure rate with publisher ICE timeouts  
After: 0% failure rate in extensive testing

## Impact

This should also fix the issue reported in https://github.com/livekit/client-sdk-android/issues/721 by @Christophe-DC and others experiencing connection instability when sending data messages immediately after room connection.