### PR TITLE
#721 Fix publisher negotiation reliability by preventing overlapping renegotiations

### DIFF
--- a/.changeset/fix-publisher-negotiation-race.md
+++ b/.changeset/fix-publisher-negotiation-race.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix publisher negotiation reliability by preventing overlapping renegotiations.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/util/PeerConnectionStateObservable.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/util/PeerConnectionStateObservable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit, Inc.
+ * Copyright 2024-2025 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.livekit.android.room.util
 import io.livekit.android.util.FlowObservable
 import io.livekit.android.util.flow
 import io.livekit.android.webrtc.isConnected
+import io.livekit.android.webrtc.isDisconnected
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
 import livekit.org.webrtc.PeerConnection.PeerConnectionState
@@ -36,6 +37,21 @@ internal suspend fun PeerConnectionStateObservable.waitUntilConnected() {
     this::connectionState.flow
         .takeWhile {
             !it.isConnected()
+        }
+        .collect()
+}
+
+/**
+ * Waits until the connection reaches a stable terminal state:
+ * [PeerConnectionState.isConnected] or [PeerConnectionState.isDisconnected].
+ *
+ * Note: [PeerConnectionState.isDisconnected] intentionally excludes the temporary
+ * [PeerConnectionState.DISCONNECTED] state and only treats FAILED/CLOSED as disconnected.
+ */
+internal suspend fun PeerConnectionStateObservable.waitUntilConnectedOrDisconnected() {
+    this::connectionState.flow
+        .takeWhile {
+            !it.isConnected() && !it.isDisconnected()
         }
         .collect()
 }


### PR DESCRIPTION
Follow-up: fixes https://github.com/livekit/client-sdk-android/issues/721

PR #789 added a mutex but used `tryLock()`, which released the mutex before connection completed, still allowing overlapping renegotiations (sorry, @davidliu).

## Fix

- Use `withLock()` instead of `tryLock()` so negotiation attempts wait instead of being skipped
- Hold the mutex until connection completes (or times out) to prevent overlapping renegotiations
- Move `hasPublished = true` before the `client.isConnected` check for proper reconnect handling
- Add `@Volatile` to `hasPublished` for thread-safe memory visibility
- Ensure the negotiation mutex only waits until the publisher connection is either connected or definitively failed (`waitUntilConnectedOrDisconnected`), so failed negotiations don't delay reconnect.
