### PR TITLE
#296 Fix camera indicator remaining on after network disconnection

### DIFF
--- a/.changeset/fix-camera-indicator-orphaned-tracks.md
+++ b/.changeset/fix-camera-indicator-orphaned-tracks.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed camera indicator remaining on after network disconnection by disposing orphaned tracks from failed reconnection attempts (#296)

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -1644,6 +1644,28 @@ internal constructor(
                 }
             }
         }
+
+        // Dispose tracks that were saved for republishing but never got republished.
+        // This happens when reconnection fails after prepareForFullReconnect() was called.
+        val republishesToDispose = republishes?.toList() ?: emptyList()
+        for (pub in republishesToDispose) {
+            val track = pub.track
+            if (track != null) {
+                try {
+                    track.stop()
+                } catch (e: Exception) {
+                    LKLog.d(e) { "Exception stopping republish track:" }
+                }
+
+                try {
+                    track.dispose()
+                } catch (e: Exception) {
+                    LKLog.d(e) { "Exception disposing republish track:" }
+                }
+            }
+        }
+        republishes = null
+
         defaultAudioTrack?.dispose()
         defaultAudioTrack = null
         defaultVideoTrack?.dispose()


### PR DESCRIPTION
Fixes #296

## Problem
Camera active indicator remains on indefinitely when a Room is disconnected due to network failure (e.g., turning off WiFi/mobile data). This issue was reported in #296 and affects privacy, user experience, and battery life.

## Root Cause
When network disconnection triggers reconnection attempts:
1. `LocalParticipant.prepareForFullReconnect()` clears `trackPublications` and moves tracks to a `republishes` list for later republishing
2. When reconnection fails permanently, the room disconnects
3. `LocalParticipant.cleanup()` only disposes tracks in `trackPublications` (which is now empty)
4. Tracks in the `republishes` list are orphaned and never disposed, leaving camera resources allocated

## Solution
Modified `LocalParticipant.cleanup()` to also dispose tracks from the `republishes` list that were saved for reconnection but never got republished. This ensures proper camera resource cleanup even when reconnection fails.

## Testing
Tested the fix by:
1. Connecting to a room with video enabled
2. Turning off internet connection to trigger failed reconnection
3. Verifying camera indicator turns off when room disconnects

The camera indicator now properly turns off after failed reconnection attempts.

cc @davidliu