### PR TITLE
Harden reconnection state flags and data channel receive state

### DIFF
--- a/.changeset/harden-reconnect-state.md
+++ b/.changeset/harden-reconnect-state.md
@@ -1,0 +1,6 @@
+---
+"client-sdk-android": patch
+---
+
+Improve reconnection reliability by hardening state flags and synchronizing data channel receive state.
+

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -150,8 +150,12 @@ internal constructor(
             }
         }
     }
+
+    @Volatile
     internal var reconnectType: ReconnectType = ReconnectType.DEFAULT
     private var reconnectingJob: Job? = null
+
+    @Volatile
     private var fullReconnectOnNext = false
 
     private val pendingTrackResolvers: MutableMap<String, Continuation<LivekitModels.TrackInfo>> =
@@ -192,6 +196,8 @@ internal constructor(
     private val reliableReceivedState = TTLMap<String, Int>(RELIABLE_RECEIVE_STATE_TTL_MS)
 
     private var isSubscriberPrimary = false
+
+    @Volatile
     private var isClosed = true
 
     private var hasPublished = false
@@ -1327,11 +1333,13 @@ internal constructor(
                     .build()
             }
 
-        val dataChannelReceiveStates = this.reliableReceivedState.map { (participantSid, sequence) ->
-            with(LivekitRtc.DataChannelReceiveState.newBuilder()) {
-                publisherSid = participantSid
-                lastSeq = sequence
-                build()
+        val dataChannelReceiveStates = synchronized(reliableStateLock) {
+            this.reliableReceivedState.map { (participantSid, sequence) ->
+                with(LivekitRtc.DataChannelReceiveState.newBuilder()) {
+                    publisherSid = participantSid
+                    lastSeq = sequence
+                    build()
+                }
             }
         }
 


### PR DESCRIPTION
@davidliu, this change tightens concurrency around data channel reliability state and reconnection-related flags in `RTCEngine` to avoid subtle races during reconnect and resume.