### PR TITLE
Fix LocalParticipant jobs map leak on unpublish

### DIFF
--- a/.changeset/fix-localparticipant-jobs-leak.md
+++ b/.changeset/fix-localparticipant-jobs-leak.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix LocalParticipant jobs map clean-up when unpublishing tracks.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -129,7 +129,7 @@ internal constructor(
             .mapNotNull { it as? LocalTrackPublication }
             .toList()
 
-    private val jobs = mutableMapOf<Any, Job>()
+    private val jobs = mutableMapOf<LocalTrackPublication, Job>()
 
     private val rpcHandlers = Collections.synchronizedMap(mutableMapOf<String, RpcHandler>()) // methodName to handler
     private val pendingAcks = Collections.synchronizedMap(mutableMapOf<String, PendingRpcAck>()) // requestId to pending ack
@@ -940,7 +940,7 @@ internal constructor(
         val publicationJob = jobs[publication]
         if (publicationJob != null) {
             publicationJob.cancel()
-            jobs.remove(publicationJob)
+            jobs.remove(publication)
         }
 
         val sid = publication.sid


### PR DESCRIPTION
- Ensure `LocalParticipant` stores jobs in a type-safe map keyed by LocalTrackPublication.
- Fix `unpublishTrack` to remove jobs using the publication key after cancelling the job.
- Prevent accumulation of cancelled jobs and associated publication references over the room lifetime.

CC @davidliu 