### PR TITLE
#808 Fixed ProGuard crash with Klaxon reflection-based classes

### DIFF
--- a/.changeset/silent-klaxon-proguard.md
+++ b/.changeset/silent-klaxon-proguard.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed ProGuard/R8 minification crash in release builds when using AgentAttributes. Added @Keep annotations to Klaxon-based data classes and updated ProGuard rules to prevent obfuscation of reflection-based JSON parsing classes. #808

--- a/livekit-android-sdk/consumer-rules.pro
+++ b/livekit-android-sdk/consumer-rules.pro
@@ -39,3 +39,11 @@
 # Protobuf
 #########################################
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+
+# Klaxon JSON parsing
+#########################################
+# Klaxon uses reflection and doesn't ship ProGuard rules.
+# Keep Klaxon library classes for reflection to work
+-keep class com.beust.klaxon.** { *; }
+-keep interface com.beust.klaxon.** { *; }
+# Data classes using Klaxon should be annotated with @Keep at the source level

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/types/AgentTypes.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/types/AgentTypes.kt
@@ -17,6 +17,7 @@
 package io.livekit.android.room.types
 
 import android.annotation.SuppressLint
+import androidx.annotation.Keep
 import com.beust.klaxon.Converter
 import com.beust.klaxon.Json
 import com.beust.klaxon.JsonValue
@@ -38,6 +39,7 @@ internal val klaxon = Klaxon()
     .convert(AgentOutput::class, { AgentOutput.fromValue(it.string!!) }, { "\"${it.value}\"" })
     .convert(AgentSdkState::class, { AgentSdkState.fromValue(it.string!!) }, { "\"${it.value}\"" })
 
+@Keep
 data class AgentAttributes(
     @Json(name = "lk.agent.inputs")
     val lkAgentInputs: List<AgentInput>? = null,
@@ -58,6 +60,7 @@ data class AgentAttributes(
     }
 }
 
+@Keep
 enum class AgentInput(val value: String) {
     Audio("audio"),
     Text("text"),
@@ -73,6 +76,7 @@ enum class AgentInput(val value: String) {
     }
 }
 
+@Keep
 enum class AgentOutput(val value: String) {
     Audio("audio"),
     Transcription("transcription");
@@ -87,6 +91,7 @@ enum class AgentOutput(val value: String) {
 }
 
 // Renamed from AgentState to AgentSdkState to avoid naming conflicts elsewhere.
+@Keep
 enum class AgentSdkState(val value: String) {
     Idle("idle"),
     Initializing("initializing"),
@@ -109,6 +114,7 @@ enum class AgentSdkState(val value: String) {
 /**
  * Schema for transcription-related attributes
  */
+@Keep
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class TranscriptionAttributes(


### PR DESCRIPTION
@davidliu , this fixes the release crash described in https://github.com/livekit/client-sdk-android/issues/808

Commit https://github.com/livekit/client-sdk-android/commit/4bf585ecdd227a95fbeb2def10f9542e925389c9 introduced two data classes (`AgentAttributes` and `TranscriptionAttributes`) that use Klaxon for JSON parsing via reflection. However, no ProGuard rules were added to protect these classes from obfuscation.