### PR TITLE
Improve thread-safety and reconnection reliability for hasPublished flag

### DIFF
--- a/.changeset/fix-hasPublished-thread-safety.md
+++ b/.changeset/fix-hasPublished-thread-safety.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Improve thread-safety and reconnection reliability for hasPublished flag.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -200,6 +200,7 @@ internal constructor(
     @Volatile
     private var isClosed = true
 
+    @Volatile
     private var hasPublished = false
 
     private var coroutineScope = CloseableCoroutineScope(SupervisorJob() + ioDispatcher)
@@ -676,11 +677,13 @@ internal constructor(
     }
 
     internal fun negotiatePublisher() {
+        // Mark intent to publish before checking Signal state so reconnect() can
+        // re-trigger negotiation even if the first attempt occurs before Signal connects.
+        hasPublished = true
+
         if (!client.isConnected) {
             return
         }
-
-        hasPublished = true
 
         coroutineScope.launch {
             if (negotiatePublisherMutex.tryLock()) {


### PR DESCRIPTION
@davidliu, this PR cherry-picks the independent fixes from #797 that remain valuable after #813 was merged.

Changes:

- Add `@Volatile` to `hasPublished` for proper memory visibility across threads
- Move `hasPublished = true` before the connection check so reconnect() can re-trigger negotiation even if the first attempt occurs before Signal connects

These changes improve thread-safety and fix a reconnection edge case where the publisher intent could be lost if negotiation was triggered before the signal client connected.