### PR TITLE
Fixed impossible empty streams check in Room.onAddTrack

### DIFF
--- a/.changeset/fix-empty-streams-check.md
+++ b/.changeset/fix-empty-streams-check.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed impossible empty streams check in Room.onAddTrack that could crash if WebRTC called onAddTrack with an empty streams array.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -1156,7 +1156,7 @@ constructor(
      * @suppress
      */
     override fun onAddTrack(receiver: RtpReceiver, track: MediaStreamTrack, streams: Array<out MediaStream>) {
-        if (streams.count() < 0) {
+        if (streams.isEmpty()) {
             LKLog.i { "add track with empty streams?" }
             return
         }


### PR DESCRIPTION
Fixed impossible condition  to  to prevent potential crash.