### PR TITLE
Fixed non-local return in onConnectionQuality

### DIFF
--- a/.changeset/fix-connection-quality-return.md
+++ b/.changeset/fix-connection-quality-return.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed non-local return in `onConnectionQuality` that caused lost connection quality updates for remaining participants when one participant was not found in the list.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -1266,7 +1266,7 @@ constructor(
     override fun onConnectionQuality(updates: List<LivekitRtc.ConnectionQualityInfo>) {
         updates.forEach { info ->
             val quality = ConnectionQuality.fromProto(info.quality)
-            val participant = getParticipantBySid(info.participantSid) ?: return
+            val participant = getParticipantBySid(info.participantSid) ?: return@forEach
             participant.connectionQuality = quality
             eventBus.postEvent(RoomEvent.ConnectionQualityChanged(this, participant, quality), coroutineScope)
         }


### PR DESCRIPTION
Fixed non-local return in `onConnectionQuality` that caused lost connection quality updates for remaining participants when one participant was not found in the list.