### PR TITLE
Fixed PeerConnectionTransport coroutine scope not being cancelled on close

### DIFF
--- a/.changeset/fix-pct-scope-not-cancelled.md
+++ b/.changeset/fix-pct-scope-not-cancelled.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed PeerConnectionTransport coroutine scope not being cancelled on close.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
@@ -44,6 +44,7 @@ import io.livekit.android.webrtc.peerconnection.launchBlockingOnRTCThread
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import livekit.org.webrtc.IceCandidate
 import livekit.org.webrtc.MediaConstraints
@@ -309,6 +310,7 @@ constructor(
             isClosed.set(true)
             peerConnection.dispose()
         }
+        coroutineScope.cancel()
     }
 
     fun updateRTCConfig(config: RTCConfiguration) {


### PR DESCRIPTION
Cancel the coroutine scope in `PeerConnectionTransport.close()` to make cleanup intent explicit

The scope would be garbage collected anyway when the transport is dereferenced, but explicit cancellation is cleaner and ensures any pending debounce jobs are cancelled immediately.