### PR TITLE
Fix thread visibility issues in SignalClient

### DIFF
--- a/.changeset/fix-signal-client-volatile.md
+++ b/.changeset/fix-signal-client-volatile.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix thread visibility issues in SignalClient that could cause messages to be silently dropped.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
@@ -79,9 +79,14 @@ constructor(
     private val ioDispatcher: CoroutineDispatcher,
     private val networkInfo: NetworkInfo,
 ) : WebSocketListener() {
+    @Volatile
     var isConnected = false
         private set
+
+    @Volatile
     private var currentWs: WebSocket? = null
+
+    @Volatile
     private var isReconnecting: Boolean = false
     var listener: Listener? = null
     internal var serverVersion: Semver? = null


### PR DESCRIPTION
Added `@Volatile` to `isConnected`, `currentWs`, and `isReconnecting` fields in `SignalClient` to ensure proper memory visibility across threads.

These fields are accessed from multiple threads (OkHttp WebSocket callbacks and IO dispatcher coroutines) without synchronization, which could cause:
- Messages silently dropped if the callback thread doesn't see the updated `currentWs`
- Message sending failures if the IO dispatcher doesn't see the updated connection state