### PR TITLE
Fix ConcurrentModificationException in LocalAudioTrack.dispose()

### DIFF
--- a/.changeset/fix-local-audio-track-dispose.md
+++ b/.changeset/fix-local-audio-track-dispose.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed `ConcurrentModificationException` in `LocalAudioTrack.dispose()` when sinks are registered.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrack.kt
@@ -171,9 +171,9 @@ constructor(
     override fun dispose() {
         synchronized(trackSinks) {
             for (sink in trackSinks) {
-                trackSinks.remove(sink)
                 audioRecordSamplesDispatcher.unregisterSink(sink)
             }
+            trackSinks.clear()
         }
         super.dispose()
     }


### PR DESCRIPTION
Fixed collection modification during iteration in `LocalAudioTrack.dispose()`.