### PR TITLE
Fix race condition in PeerConnectionTransport.trackBitrates

### DIFF
--- a/.changeset/fix-track-bitrates-race-condition.md
+++ b/.changeset/fix-track-bitrates-race-condition.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed race condition in `PeerConnectionTransport.trackBitrates` by ensuring writes happen on the RTC thread.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt
@@ -325,11 +325,15 @@ constructor(
     }
 
     fun registerTrackBitrateInfo(cid: String, trackBitrateInfo: TrackBitrateInfo) {
-        trackBitrates[TrackBitrateInfoKey.Cid(cid)] = trackBitrateInfo
+        executeRTCIfNotClosed {
+            trackBitrates[TrackBitrateInfoKey.Cid(cid)] = trackBitrateInfo
+        }
     }
 
     fun registerTrackBitrateInfo(transceiver: RtpTransceiver, trackBitrateInfo: TrackBitrateInfo) {
-        trackBitrates[TrackBitrateInfoKey.Transceiver(transceiver)] = trackBitrateInfo
+        executeRTCIfNotClosed {
+            trackBitrates[TrackBitrateInfoKey.Transceiver(transceiver)] = trackBitrateInfo
+        }
     }
 
     suspend fun isConnected(): Boolean {


### PR DESCRIPTION
## Problem

> Code references below are pinned to [`main@46da678`](https://github.com/livekit/client-sdk-android/commit/46da6784bec2ac124972738764a8e18702a78ee3).

[`PeerConnectionTransport.trackBitrates`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt#L96) is a plain `mutableMapOf<...>()` (a `LinkedHashMap`) with no thread-safety. Reads and writes on it race inside a single `LocalParticipant.negotiate()` call.

[`engine.createSenderTransceiver(...)`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt#L682) causes WebRTC to fire `onRenegotiationNeeded`. That goes through [`PublisherTransportObserver.onRenegotiationNeeded()`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/PublisherTransportObserver.kt#L56-L60) and `engine.negotiatePublisher()` into the [20ms-debounced `negotiate` field](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt#L146-L152). When the debounce closes, `createAndSendOffer` iterates the map on the RTC thread via [`ensureCodecBitrates(...)`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt#L217).

Still inside the same `negotiate()` body, [`engine.registerTrackBitrateInfo(...)`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt#L704-L710) writes to the map on the calling coroutine's thread. The auto-trigger is intentional and [documented in `LocalParticipant`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt#L724-L725): *"`PublisherTransportObserver.onRenegotiationNeeded()` gets triggered automatically so no need to call negotiate manually."*

If the debounce closes while a put is still in flight, iteration on the RTC thread can throw `ConcurrentModificationException` from `ensureCodecBitrates`. Any publish path that hits this `createSenderTransceiver` then `registerTrackBitrateInfo` sequence is exposed (SVC video with a `maxBitrateBps` encoding).

## Fix

Route both `registerTrackBitrateInfo` overloads through `executeRTCIfNotClosed { ... }` so writes share the single-threaded RTC executor with the read site. Same pattern as [`updateRTCConfig`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt#L321-L325) and [`addIceCandidate`](https://github.com/livekit/client-sdk-android/blob/46da6784bec2ac124972738764a8e18702a78ee3/livekit-android-sdk/src/main/java/io/livekit/android/room/PeerConnectionTransport.kt#L105-L113) in the same class. The RTC thread already serves as the lock for peer-connection-adjacent state.

The closed-state guard inside `executeRTCIfNotClosed` also makes post-close calls silently drop, matching the surrounding APIs.

## Scope

Independent of #823, which added a `Mutex` around `createAndSendOffer` for concurrent offer creation. That PR did not touch `registerTrackBitrateInfo`, so this race remained on `main`. No API or behavioral change for callers beyond the write going through the RTC executor.
