### PR TITLE
Fix race condition when sending sync state before tracks are subscribed

### DIFF
--- a/.changeset/gold-countries-flow.md
+++ b/.changeset/gold-countries-flow.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix race condition when sending sync state before tracks are subscribed

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -1010,7 +1010,10 @@ constructor(
             builder.participantSid = participant.sid.value
             for (trackPub in participant.trackPublications.values) {
                 val remoteTrackPub = (trackPub as? RemoteTrackPublication) ?: continue
-                if (remoteTrackPub.subscribed != sendUnsub) {
+
+                // Use isDesired (subscription intent) instead of isSubscribed (actual state)
+                // to avoid race condition during quick reconnect where tracks aren't attached yet.
+                if (remoteTrackPub.isDesired != sendUnsub) {
                     builder.addTrackSids(remoteTrackPub.sid)
                 }
             }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
@@ -87,7 +87,7 @@ constructor(
     internal var serverVersion: Semver? = null
     internal var serverInfo: ServerInfo? = null
     private var lastUrl: String? = null
-    private var lastOptions: ConnectOptions? = null
+    internal var lastOptions: ConnectOptions? = null
     private var lastRoomOptions: RoomOptions? = null
 
     // join will always return a JoinResponse.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/RemoteParticipant.kt
@@ -117,6 +117,7 @@ class RemoteParticipant(
                     trackInfo,
                     participant = this,
                     ioDispatcher = ioDispatcher,
+                    autoSubscribe = signalClient.lastOptions?.autoSubscribe ?: true
                 )
 
                 newTrackPublications[trackSid] = publication


### PR DESCRIPTION
Fixes issue reported in https://github.com/livekit/client-sdk-swift/issues/859