### PR TITLE
Fixed Room getting stuck in CONNECTING state after failed connect attempts.

### DIFF
--- a/.changeset/fix-room-connect-failure-state.md
+++ b/.changeset/fix-room-connect-failure-state.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed Room getting stuck in CONNECTING state after failed connect attempts.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -566,7 +566,12 @@ constructor(
         }
         connectJob.join()
 
-        error?.let { throw it }
+        error?.let {
+            if (it !is CancellationException) {
+                handleDisconnect(DisconnectReason.JOIN_FAILURE)
+            }
+            throw it
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixed bug where Room stays in CONNECTING state after a failed connect attempt, making subsequent connect calls throw `IllegalStateException`
- Room now properly resets to DISCONNECTED state and emits a `Disconnected` event with `JOIN_FAILURE` reason on connect failure

## Test plan
- Added `connectFailureResetsStateToDisconnected` test verifying state reset and event emission
- Added `connectRetryAfterFailureSucceeds` test verifying retry works after failure