### PR TITLE
Fixed audio focus not being abandoned on pre-O devices

### DIFF
--- a/.changeset/fix-audio-focus-abandon-pre-o.md
+++ b/.changeset/fix-audio-focus-abandon-pre-o.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed audio focus not being abandoned on pre-O devices due to mismatched listener instance.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/audio/AudioFocusHandler.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/audio/AudioFocusHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 LiveKit, Inc.
+ * Copyright 2023-2025 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ constructor(context: Context) : AudioHandler {
             audioRequest = null
         } else {
             @Suppress("DEPRECATION")
-            audioManager.abandonAudioFocus(onAudioFocusChangeListener)
+            audioManager.abandonAudioFocus(audioFocusListener)
         }
     }
 


### PR DESCRIPTION
Fixed audio focus not being released on pre-O devices (API < 26) due to using the wrong listener instance in `abandonAudioFocus()`