### PR TITLE
Fixed potential crash and hang in ScreenCaptureConnection

### DIFF
--- a/.changeset/fix-screen-capture-connection-hang.md
+++ b/.changeset/fix-screen-capture-connection-hang.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed ScreenCaptureConnection suspending forever when bindService fails and crashing when resuming canceled continuations.


### PR DESCRIPTION
## Summary

- Fixed crash when resuming canceled continuations by adding `invokeOnCancellation` cleanup
- Added defensive check for `bindService()` failure

## Problem

**Crash on cancellation (main issue):** If a coroutine waiting in `queuedConnects` is canceled (e.g., user navigates away, timeout), the continuation remains in the set. When `handleConnect()` later calls `resume()` on the canceled continuation, it throws `IllegalStateException`.

**Infinite hang (defensive):** The `bindService()` return value was ignored. While the service is declared in the SDK manifest and this is unlikely to fail in practice, if it ever does, the coroutine would suspend indefinitely with no indication of what went wrong.

## Solution

- Add `invokeOnCancellation` handler to remove the continuation from `queuedConnects` when the coroutine is canceled
- Check `bindService()` return value and throw immediately with a descriptive error if binding fails