### PR TITLE
Fixed file descriptor leak in ByteStreamSender

### DIFF
--- a/.changeset/fix-byte-stream-source-leak.md
+++ b/.changeset/fix-byte-stream-source-leak.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed file descriptor leak in ByteStreamSender where Source was not closed after reading.


### PR DESCRIPTION
- Fixed file descriptor leak where `Source` was never closed in `ByteStreamSender.write(source: Source)`
- Each call to `writeFile()` or `write(InputStream)` would leak a file descriptor, eventually causing "Too many open files" errors