### PR TITLE
bugfix:协程挂起不会创建新的webSocket

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/SignalClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 LiveKit, Inc.
+ * Copyright 2023-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ constructor(
             suspendCancellableCoroutine { cont ->
                 // Wait for join response through WebSocketListener
                 joinContinuation = cont
-                //When a coroutine is canceled, WebSocket must be interrupted.
+                // When a coroutine is canceled, WebSocket must be interrupted.
                 cont.invokeOnCancellation {
                     LKLog.w { "connect cancelled, abort websocket" }
                     currentWs?.cancel()


### PR DESCRIPTION
```
private suspend fun connect(
        url: String,
        token: String,
        options: ConnectOptions,
        roomOptions: RoomOptions,
    ): Either<JoinResponse, Either<ReconnectResponse, Unit>> {
        // Clean up any pre-existing connection.
        close(reason = "Starting new connection", shouldClearQueuedRequests = false)
        .....  // If the connection to the server fails, the coroutine here will remain suspended.
        return suspendCancellableCoroutine {
            joinContinuation = it
            currentWs = websocketFactory.newWebSocket(request, this)
        }
    }
```
The inability to connect to the server will cause the coroutine to remain suspended and will not initiate a new connection.

Test steps
step1
Set a breakpoint in AlertDialog.Builder(), then wait 15 seconds to allow the room to reconnect.
```
binding.message.setOnClickListener {
            val editText = EditText(this)
            AlertDialog.Builder(this)
                .setTitle("Send Message")
                .setView(editText)
                .setPositiveButton("Send") { dialog, _ ->
                    viewModel.sendData(editText.text?.toString() ?: "")
                }
                .setNegativeButton("Cancel") { _, _ -> }
                .create()
                .show()
        }
```
step2
The code `websocketFactory.newWebSocket(request, this)` will be executed, but nothing will happen; no new connection will be initiated.

