### PR TITLE
perf: skip Klaxon parsing for empty agent attribute maps

### DIFF
--- a/.changeset/sixty-radios-switch.md
+++ b/.changeset/sixty-radios-switch.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+perf: Skip Klaxon parsing for empty agent attribute maps

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/types/AgentTypesExt.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/types/AgentTypesExt.kt
@@ -28,6 +28,10 @@ internal fun AgentAttributes.Companion.fromJsonObject(jsonObject: JsonObject) =
  * @suppress
  */
 fun AgentAttributes.Companion.fromMap(map: Map<String, *>): AgentAttributes {
+    if (map.values.all { it == null }) {
+        return AgentAttributes()
+    }
+
     return fromJsonObject(JsonObject(map)) ?: AgentAttributes()
 }
 


### PR DESCRIPTION
## Problem

`AgentAttributes.fromStringMap()` was very slow on very first invocation for empty maps taking upto 1 seconds in some cases.

## Solution
Add early return when the input map is empty, returning a default 
`AgentAttributes()` directly. This avoids triggering Klaxon parsing 
when there's nothing to parse. 