### PR TITLE
bugfix: Fix the issue of incorrect connectionState status

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -313,7 +313,14 @@ internal constructor(
                     if (newState.isConnected()) {
                         connectionState = ConnectionState.CONNECTED
                     } else if (newState.isDisconnected()) {
-                        connectionState = ConnectionState.DISCONNECTED
+                        // Only transition to DISCONNECTED when not already in a reconnection
+                        // intermediate state (RESUMING/RECONNECTING). In those states the
+                        // reconnect flow owns connectionState; overwriting it here would
+                        // silently swallow the disconnect and prevent the app from being notified.
+                        val current = connectionState
+                        if (current != ConnectionState.RESUMING && current != ConnectionState.RECONNECTING) {
+                            connectionState = ConnectionState.DISCONNECTED
+                        }
                     }
                 }
 


### PR DESCRIPTION
```
2026-03-14 18:14:57.361 LkLog                com...rexm.improject  D  WebSocket： websocket onFailure() t.error = Read error: ssl=0x749f6dfbc8: I/O error during system call, Software caused connection abort
2026-03-14 18:14:57.367 LkLog                com...rexm.improject  D  WebSocket：failed to validate connection
2026-03-14 18:14:57.379 LkLog                com...rexm.improject  D  WebSocket：websocket failure: null
2026-03-14 18:14:57.385 LkLog                com...rexm.improject  D  WebSocket：websocket closed
2026-03-14 18:14:57.391 LkLog                com...rexm.improject  D  RTC connect：connect retries = 0
2026-03-14 18:14:57.391 LkLog                com...rexm.improject  D  RTC connect：Reconnecting to signal, attempt 1
2026-03-14 18:14:57.492 LkLog                com...rexm.improject  D  RTC connect：connectionState.flow oldVal.connectionState = CONNECTED newVal.connectionState = RESUMING
2026-03-14 18:14:57.493 LkLog                com...rexm.improject  D  RTC connect：Attempting soft reconnect.
2026-03-14 18:14:57.493 LkLog                com...rexm.improject  D  WebSocket：Closing SignalClient: code = 1000, reason = Starting new connection
2026-03-14 18:14:57.496 LkLog                com...rexm.improject  D  WebSocket： connecting to wss://livekit.test.im.cn/rtc?protocol=13&reconnect=1&sid=PA_j2C578b7WryN&auto_subscribe=1&adaptive_stream=0&sdk=android&version=2.23.5.testlog.7&device_model=HUAWEI ELS-AN00&os=android&os_version=10&network=
2026-03-14 18:14:57.500 LkLog                com...rexm.improject  D  WebSocket： websocket onFailure() t.error = Unable to resolve host "livekit.test.xmsharetalk.cn": No address associated with hostname
2026-03-14 18:15:03.049 LkLog                com...rexm.improject  D  API_CALL：onIceConnection new state: DISCONNECTED
2026-03-14 18:15:13.064 LkLog                com...rexm.improject  D  API_CALL：onIceConnection new state: FAILED
2026-03-14 18:15:13.065 LkLog                com...rexm.improject  D  RTC connect：connectionState.flow oldVal.connectionState = RESUMING newVal.connectionState = DISCONNECTED
2026-03-14 18:15:13.065 LkLog                com...rexm.improject  D  RTC connect：primary ICE disconnected
2026-03-14 18:15:14.058 LkLog                com...rexm.improject  D  API_CALL：publisherObserver.connectionChangeListener reconnect()
2026-03-14 18:15:14.060 LkLog                com...rexm.improject  D  RTC connect：Reconnection is already in progress
```
Fix the incorrect connectionState

Timeline:
1. WebSocket exception → reconnect() is called → connectionState = RESUMING
2. ICE is also disconnected → connectionStateListener is triggered → connectionState = DISCONNECTED (overwritten)
3. Inconsistent state: reconnect() thinks it is in RESUMING state, but it is actually already in DISCONNECTED state

Original code (with bug):
```
// reconnect() 
connectionState = ConnectionState.RESUMING 

// ICE Disconnected
connectionStateListener: { newState ->
    if (newState.isDisconnected()) {
        connectionState = ConnectionState.DISCONNECTED   
    }
}

// flowDelegate callback
oldVal = RESUMING, newVal = DISCONNECTED
// Not meeting any notification conditions, the application layer cannot receive the callback
```

After repair:
```
// Inside reconnect()
connectionState = ConnectionState.RESUMING  // set to RESUMING
// Disconnect ICE later
connectionStateListener: { newState ->
    if (newState.isDisconnected()) {
        val current = connectionState
        if (current != ConnectionState.RESUMING && current != ConnectionState.RECONNECTING) {
            connectionState = ConnectionState.DISCONNECTED
        }
        // current == RESUMING, do not overwrite, maintain the RESUMING state
    }
}
// After successful reconnection
connectionState = ConnectionState.CONNECTED
// flowDelegate callback: oldVal = RESUMING, newVal = CONNECTED
// Trigger onEngineResumed()
```

Why does it cause problems
1. Inconsistent state: The reconnect() process believes it is in RESUMING state, but the connectionState is already DISCONNECTED
2. No perception at the application layer: The transition from RESUMING to DISCONNECTED does not trigger any application layer callbacks
3. There is no callback after the reconnection is completed: even if the reconnection is successful, subsequent state transitions may still encounter issues due to the state already being DISCONNECTED