### PR TITLE
fix IllegalArgumentException when rpc is over 15K

### DIFF
--- a/.changeset/dull-masks-matter.md
+++ b/.changeset/dull-masks-matter.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix LocalParticipant.publishData throwing exception for packets over 15KB

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -980,7 +980,7 @@ internal constructor(
         identities: List<Identity>? = null,
     ): Result<Unit> {
         if (data.size > RTCEngine.MAX_DATA_PACKET_SIZE) {
-            throw IllegalArgumentException("cannot publish data larger than " + RTCEngine.MAX_DATA_PACKET_SIZE)
+            return Result.failure(IllegalArgumentException("cannot publish data larger than " + RTCEngine.MAX_DATA_PACKET_SIZE))
         }
 
         val kind = when (reliability) {


### PR DESCRIPTION
The current code will thro a IllegalArgumentException when RPC is over 15K
While the function comment says that it will return failure containing the exception
