### PR TITLE
Fixed silent loss of reliable data on send failure and resume replay

### DIFF
--- a/.changeset/quiet-ducks-deliver.md
+++ b/.changeset/quiet-ducks-deliver.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fixed silent loss of reliable data when DataChannel.send returned false and when buffered items were replayed across multiple resumes.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -678,7 +678,12 @@ internal constructor(
                         connectionState = ConnectionState.CONNECTED
                     }
                     if (lastMessageSeq != null) {
-                        resendReliableMessagesForResume(lastMessageSeq)
+                        resendReliableMessagesForResume(lastMessageSeq).onFailure { e ->
+                            LKLog.w(e) {
+                                "Reliable data replay did not complete on resume; " +
+                                    "buffered items remain queued for the next resume."
+                            }
+                        }
                     }
                     // Is connected, notify and return.
                     regionUrlProvider?.clearAttemptedRegions()
@@ -757,29 +762,39 @@ internal constructor(
                     }
                 }
 
-                if (dataPacket.kind == LivekitModels.DataPacket.Kind.RELIABLE) {
+                val isReliable = dataPacket.kind == LivekitModels.DataPacket.Kind.RELIABLE
+                if (isReliable) {
                     dataPacket = dataPacket.toBuilder()
                         .setSequence(reliableDataSequence)
                         .build()
-                    reliableDataSequence++
                 }
 
-                val byteBuffer = ByteBuffer.wrap(dataPacket.toByteArray())
+                val packetBytes = dataPacket.toByteArray()
 
-                if (dataPacket.kind == LivekitModels.DataPacket.Kind.RELIABLE) {
-                    reliableMessageBuffer.queue(DataPacketItem(byteBuffer, dataPacket.sequence))
-                    if (this.connectionState == ConnectionState.RECONNECTING) {
-                        return Result.success(Unit)
-                    }
+                if (isReliable && this.connectionState == ConnectionState.RECONNECTING) {
+                    reliableMessageBuffer.queue(DataPacketItem(ByteBuffer.wrap(packetBytes), dataPacket.sequence))
+                    reliableDataSequence++
+                    return Result.success(Unit)
                 }
                 val buf = DataChannel.Buffer(
-                    byteBuffer,
+                    ByteBuffer.wrap(packetBytes),
                     true,
                 )
                 val channel = dataChannelForKind(dataPacket.kind)
                     ?: throw RoomException.ConnectException("channel not established for ${dataPacket.kind.name}")
 
-                channel.send(buf)
+                if (!channel.send(buf)) {
+                    return Result.failure(
+                        RoomException.ConnectException("failed to send data packet for ${dataPacket.kind.name}"),
+                    )
+                }
+
+                if (isReliable) {
+                    // Wrap a fresh ByteBuffer so the queued item's position stays at 0; the
+                    // ByteBuffer just sent has been drained by DataChannel.send.
+                    reliableMessageBuffer.queue(DataPacketItem(ByteBuffer.wrap(packetBytes), dataPacket.sequence))
+                    reliableDataSequence++
+                }
             } catch (e: Exception) {
                 e.rethrowIfCancellationSignal()
                 return Result.failure(e)
@@ -808,8 +823,17 @@ internal constructor(
 
         synchronized(reliableStateLock) {
             reliableMessageBuffer.popToSequence(lastMessageSeq)
-            reliableMessageBuffer.getAll().forEach { item ->
-                channel.send(DataChannel.Buffer(item.data, true))
+            for (item in reliableMessageBuffer.getAll()) {
+                // Send a duplicate so the underlying buffer keeps position=0 and survives
+                // multiple resume attempts. DataChannel.send drains the buffer's position to
+                // its limit; without duplicate(), the second replay would send empty bytes.
+                if (!channel.send(DataChannel.Buffer(item.data.duplicate(), true))) {
+                    return Result.failure(
+                        RoomException.ConnectException(
+                            "failed to replay reliable data packet at sequence ${item.sequence}",
+                        ),
+                    )
+                }
             }
         }
 

--- a/livekit-android-test/src/main/java/io/livekit/android/test/mock/MockDataChannel.kt
+++ b/livekit-android-test/src/main/java/io/livekit/android/test/mock/MockDataChannel.kt
@@ -23,6 +23,17 @@ class MockDataChannel(private val label: String?) : DataChannel(1L) {
     var observer: Observer? = null
     var sentBuffers = mutableListOf<Buffer>()
 
+    /** Snapshot of the bytes visible at send time, captured via the Buffer's current position/limit. */
+    var sentPayloads = mutableListOf<ByteArray>()
+    var sendResult = true
+
+    /**
+     * When true, [send] advances the buffer's position to its limit, mirroring
+     * the real WebRTC wrapper which drains the buffer via `ByteBuffer.get(byte[])`.
+     * Off by default to keep existing tests that read from `sentBuffers` working.
+     */
+    var consumeSentBuffer = false
+
     private var stateBacking: State = State.OPEN
     var state: State
         get() {
@@ -57,6 +68,7 @@ class MockDataChannel(private val label: String?) : DataChannel(1L) {
 
     fun clearSentBuffers() {
         sentBuffers.clear()
+        sentPayloads.clear()
     }
 
     override fun registerObserver(observer: Observer?) {
@@ -92,7 +104,15 @@ class MockDataChannel(private val label: String?) : DataChannel(1L) {
     override fun send(buffer: Buffer): Boolean {
         ensureNotDisposed()
         sentBuffers.add(buffer)
-        return true
+        // Capture what native WebRTC would receive at this moment (position..limit).
+        val savedPos = buffer.data.position()
+        val payload = ByteArray(buffer.data.remaining())
+        buffer.data.get(payload)
+        sentPayloads.add(payload)
+        if (!consumeSentBuffer) {
+            buffer.data.position(savedPos)
+        }
+        return sendResult
     }
 
     override fun close() {

--- a/livekit-android-test/src/test/java/io/livekit/android/room/RTCEngineMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/RTCEngineMockE2ETest.kt
@@ -42,6 +42,7 @@ import livekit.LivekitModels.DataPacket
 import livekit.LivekitRtc
 import livekit.org.webrtc.PeerConnection
 import org.junit.Assert
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -410,6 +411,49 @@ class RTCEngineMockE2ETest : MockE2ETest() {
         testScheduler.advanceUntilIdle()
         val sid = wsFactory.request.url.queryParameter(SignalClient.CONNECT_QUERY_PARTICIPANT_SID)
         assertEquals(TestData.JOIN.join.participant.sid, sid)
+    }
+
+    @Test
+    fun resendReliableMessagesReplaysFullPayloadAcrossMultipleResumes() = runTest {
+        connect()
+        val pubPeerConnection = getPublisherPeerConnection()
+        val pubDataChannel = pubPeerConnection
+            .dataChannels[RTCEngine.RELIABLE_DATA_CHANNEL_LABEL] as MockDataChannel
+        pubDataChannel.consumeSentBuffer = true
+
+        val payload = "hello-resume".toByteArray()
+        val publishResult = room.localParticipant.publishData(payload)
+        assertTrue(publishResult.isSuccess)
+
+        // Two consecutive resumes without server progress (lastMessageSeq=0 pops nothing).
+        rtcEngine.resendReliableMessagesForResume(0)
+        rtcEngine.resendReliableMessagesForResume(0)
+
+        // 1 initial publish + 2 replays.
+        assertEquals(3, pubDataChannel.sentPayloads.size)
+
+        // Both replays must carry the original payload, not an empty buffer.
+        val replay1 = DataPacket.parseFrom(pubDataChannel.sentPayloads[1])
+        val replay2 = DataPacket.parseFrom(pubDataChannel.sentPayloads[2])
+        assertArrayEquals(payload, replay1.user.payload.toByteArray())
+        assertArrayEquals(payload, replay2.user.payload.toByteArray())
+    }
+
+    @Test
+    fun resendReliableMessagesReturnsFailureWhenReplaySendFails() = runTest {
+        connect()
+        val pubPeerConnection = getPublisherPeerConnection()
+        val pubDataChannel = pubPeerConnection
+            .dataChannels[RTCEngine.RELIABLE_DATA_CHANNEL_LABEL] as MockDataChannel
+
+        val publishResult = room.localParticipant.publishData("queued".toByteArray())
+        assertTrue(publishResult.isSuccess)
+
+        pubDataChannel.sendResult = false
+
+        val resendResult = rtcEngine.resendReliableMessagesForResume(0)
+        assertTrue(resendResult.isFailure)
+        assertTrue(resendResult.exceptionOrNull() is RoomException.ConnectException)
     }
 
     /**

--- a/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
@@ -899,4 +899,26 @@ class LocalParticipantMockE2ETest : MockE2ETest() {
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is RoomException.ConnectException)
     }
+
+    @Test
+    fun publishDataReturnsFailureWhenDataChannelSendFails() = runTest {
+        connect()
+        val pubPeerConnection = getPublisherPeerConnection()
+        val pubDataChannel = pubPeerConnection.dataChannels[RTCEngine.RELIABLE_DATA_CHANNEL_LABEL] as MockDataChannel
+        pubDataChannel.sendResult = false
+
+        val result = room.localParticipant.publishData("hello".toByteArray())
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is RoomException.ConnectException)
+
+        pubDataChannel.sendResult = true
+        val retryResult = room.localParticipant.publishData("hello".toByteArray())
+
+        assertTrue(retryResult.isSuccess)
+        assertEquals(2, pubDataChannel.sentBuffers.size)
+
+        val retriedPacket = DataPacket.parseFrom(ByteString.copyFrom(pubDataChannel.sentBuffers[1].data))
+        assertEquals(1, retriedPacket.sequence)
+    }
 }


### PR DESCRIPTION
## Summary

We rely on reliable `LocalParticipant.publishData(...)` for application-level signaling where every message must land, which is what drew my attention here.

`DataChannel.send(Buffer)` returns a `Boolean` that is `false` when the SCTP send queue is full, the channel is not `OPEN`, or the native layer rejects the buffer. `RTCEngine.sendData` discarded that result and always returned `Result.success(Unit)`, so callers using `LocalParticipant.publishData(...).getOrThrow()` to drive retry logic could not see locally rejected packets and would treat them as delivered.

While there I also looked at the resume replay path. The Android WebRTC wrapper drains a `Buffer` via `ByteBuffer.get(byte[])`, which advances the buffer's position to its limit. `reliableMessageBuffer` stores each item as a `ByteBuffer`, and `resendReliableMessagesForResume` passed the same `ByteBuffer` instance into `DataChannel.send` on every replay. If a buffered item survived more than one resume attempt without server progress on `lastMessageSeq` (back-to-back reconnects), the second and subsequent replays sent an empty buffer and `DataChannel.send` returned `true`, so no caller could detect the loss.

`resendReliableMessagesForResume` also discarded `DataChannel.send`'s boolean return value during replay, and the reconnect caller discarded the function's `Result`. An SCTP-rejected replay would therefore be silently dropped while the reconnect continued to `client.onPCConnected()`, marking the connection resumed.

## Fix

- Check the return of `channel.send(buf)` and surface `Result.failure(RoomException.ConnectException(...))` on `false`.
- For RELIABLE packets, defer `reliableMessageBuffer` queueing and `reliableDataSequence` advancement until *after* a successful send. A failed send no longer burns a sequence number or leaves a stale entry that would replay on resume; a caller retry reuses the same sequence.
- The `RECONNECTING` fast-path (queue and return success without sending) is unchanged.
- Keep `DataPacketItem.data` as `ByteBuffer` (the public type is part of the SDK ABI) and pass a fresh `ByteBuffer.wrap(packetBytes)` to `DataChannel.send` while queueing a separate `ByteBuffer.wrap(packetBytes)` in `reliableMessageBuffer`. In `resendReliableMessagesForResume`, send `item.data.duplicate()` per replay so the buffered item's position stays at 0 and survives multiple resume attempts.
- In `resendReliableMessagesForResume`, check `channel.send(...)`'s boolean per replay and return `Result.failure(RoomException.ConnectException(...))` on the first rejected item. The reconnect caller now logs the failure via `LKLog.w` instead of discarding the `Result`. Buffered items remain queued for the next legitimate soft reconnect.

  Whether the reconnect path should *also* react to a failed replay (e.g., await `bufferedAmount` low and retry in place, escalate to `onEngineDisconnected`, or have the full-reconnect path attempt reliable replay too) is a policy/behavior decision worth its own discussion. Note: simply `continue`-ing the reconnect loop on failure is not equivalent to "retry the resume" — `lastMessageSeq` is only set in the soft-reconnect branch (line 614), so the next iteration would upgrade to a full reconnect (line 574, `retries != 0`) and silently skip the replay (line 673), leaving buffered items orphaned. Open to direction from maintainers on what they'd prefer here; happy to do it in a follow-up.

## Test plan

- [x] `publishDataReturnsFailureWhenDataChannelSendFails` in `LocalParticipantMockE2ETest` asserts:
  - failed `send()` produces `Result.failure` with `RoomException.ConnectException`
  - on retry after recovery, `sentBuffers.size == 2` and the retried packet's sequence is `1` (proving the failed attempt did not consume a sequence).
- [x] `resendReliableMessagesReplaysFullPayloadAcrossMultipleResumes` in `RTCEngineMockE2ETest` publishes a reliable message and calls `resendReliableMessagesForResume(0)` twice with `consumeSentBuffer = true` (mirrors WebRTC's drain). It parses both replayed payloads back into `DataPacket` and asserts the original bytes survive repeated replay.
- [x] `resendReliableMessagesReturnsFailureWhenReplaySendFails` in `RTCEngineMockE2ETest` flips `MockDataChannel.sendResult = false` after a publish and asserts `resendReliableMessagesForResume(0)` returns `Result.failure` with `RoomException.ConnectException`.
- [x] `MockDataChannel` gained a `sentPayloads` list (snapshot of bytes visible at send time) and a `consumeSentBuffer` flag.
- [x] `./gradlew livekit-android-test:testDebugUnitTest --tests "io.livekit.android.room.RTCEngineMockE2ETest" --tests "io.livekit.android.room.participant.LocalParticipantMockE2ETest" --tests "io.livekit.android.room.RoomDataMockE2ETest" --tests "io.livekit.android.room.RoomReconnectionMockE2ETest" --rerun-tasks` passes.
- [x] `./gradlew spotlessApply` clean.
