### PR TITLE
feat: improve android-coroutines skill score (59% → 90%)

### DIFF
--- a/.agent/skills/android-coroutines/SKILL.md
+++ b/.agent/skills/android-coroutines/SKILL.md
@@ -1,32 +1,18 @@
 ---
 name: android-coroutines
-description: Authoritative rules and patterns for production-quality Kotlin Coroutines onto Android. Covers structured concurrency, lifecycle integration, and reactive streams.
+description: "Implement and review Kotlin Coroutines on Android: configure CoroutineScopes, manage Dispatchers, expose StateFlow/SharedFlow from ViewModels, collect with repeatOnLifecycle, and convert callback APIs to callbackFlow. Use when writing suspend functions, wiring up Flow or StateFlow, fixing async bugs, replacing GlobalScope, or integrating coroutines with Android lifecycle components."
 ---
 
 # Android Coroutines Expert Skill
 
-This skill provides authoritative rules and patterns for writing production-quality Kotlin Coroutines code on Android. It enforces structured concurrency, lifecycle safety, and modern best practices (2025 standards).
+## Workflow
 
-## Responsibilities
+1. **Identify scope** — Determine the correct CoroutineScope (`viewModelScope`, `lifecycleScope`, or injected `applicationScope`).
+2. **Wire data layer** — Expose data as `suspend` functions (one-shot) or `Flow` (streams) with injected Dispatchers.
+3. **Connect UI** — Collect flows using `repeatOnLifecycle(Lifecycle.State.STARTED)` and expose read-only `StateFlow`.
+4. **Verify** — Run `./gradlew test` and confirm coroutine behavior. If tests fail, check: uncaught `CancellationException` in generic `catch` blocks, `GlobalScope` usage causing leaked coroutines, missing `awaitClose` in `callbackFlow`, or hardcoded Dispatchers breaking test determinism. Run `./gradlew detektDebug` to catch structural issues.
 
-*   **Asynchronous Logic**: Implementing suspend functions, Dispatcher management, and parallel execution.
-*   **Reactive Streams**: Implementing `Flow`, `StateFlow`, `SharedFlow`, and `callbackFlow`.
-*   **Lifecycle Integration**: Managing scopes (`viewModelScope`, `lifecycleScope`) and safe collection (`repeatOnLifecycle`).
-*   **Error Handling**: Implementing `CoroutineExceptionHandler`, `SupervisorJob`, and proper `try-catch` hierarchies.
-*   **Cancellability**: Ensuring long-running operations are cooperative using `ensureActive()`.
-*   **Testing**: Setting up `TestDispatcher` and `runTest`.
-
-## Applicability
-
-Activate this skill when the user asks to:
-*   "Fetch data from an API/Database."
-*   "Perform background processing."
-*   "Fix a memory leak" related to threads/tasks.
-*   "Convert a listener/callback to Coroutines."
-*   "Implement a ViewModel."
-*   "Handle UI state updates."
-
-## Critical Rules & Constraints
+## Critical Rules
 
 ### 1. Dispatcher Injection (Testability)
 *   **NEVER** hardcode Dispatchers (e.g., `Dispatchers.IO`, `Dispatchers.Default`) inside classes.
@@ -46,11 +32,8 @@ class UserRepository {
 ```
 
 ### 2. Main-Safety
-*   All suspend functions defined in the Data or Domain layer must be **main-safe**.
-*   **One-shot calls** should be exposed as `suspend` functions.
-*   **Data changes** should be exposed as `Flow`.
-*   The caller (ViewModel) should be able to call them from `Dispatchers.Main` without blocking the UI.
-*   Use `withContext(dispatcher)` inside the repository implementation to move execution to the background.
+*   All suspend functions in Data/Domain layers must be **main-safe** — use `withContext(dispatcher)` internally.
+*   **One-shot calls**: expose as `suspend` functions. **Data streams**: expose as `Flow`.
 
 ### 3. Lifecycle-Aware Collection
 *   **NEVER** collect a flow directly in `lifecycleScope.launch` or `launchWhenStarted` (deprecated/unsafe).
@@ -83,9 +66,8 @@ viewLifecycleOwner.lifecycleScope.launch {
 *   Use `CoroutineExceptionHandler` only for top-level coroutines (inside `launch`). It has no effect inside `async` or child coroutines.
 
 ### 8. Cancellability
-*   Coroutines feature **cooperative cancellation**. They don't stop immediately unless they check for cancellation.
-*   **ALWAYS** call `ensureActive()` or `yield()` in tight loops (e.g., processing a large list, reading files) to check for cancellation.
-*   Standard functions like `delay()` and `withContext()` are already cancellable.
+*   **ALWAYS** call `ensureActive()` or `yield()` in tight loops (e.g., processing a large list, reading files).
+*   `delay()` and `withContext()` are already cancellable — no extra checks needed there.
 
 ### 9. Callback Conversion
 *   Use `callbackFlow` to convert callback-based APIs to Flow.


### PR DESCRIPTION
Hey @davidliu 👋

ran your skills through `tessl skill review` at work and found some targeted improvements for `android-coroutines`. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| android-coroutines | 59% | 90% | +31% |

picked `android-coroutines` because it had the most improvement headroom among the core skills, and coroutines are central to the SDK's async real-time communication patterns.

<details>
<summary>Changes made to <code>android-coroutines</code></summary>

- **Rewrote frontmatter description** with explicit "Use when..." clause and natural trigger terms (`suspend functions`, `Flow`, `StateFlow`, `GlobalScope`, `callbackFlow`, `repeatOnLifecycle`) so the skill gets selected reliably
- **Added a 4-step implementation workflow** (Identify scope → Wire data layer → Connect UI → Verify) with concrete validation steps including `./gradlew test` and `./gradlew detektDebug`, plus a diagnostic checklist for common failure modes
- **Removed meta-sections** ("Responsibilities" and "Applicability") that restated the description without adding actionable value - saves tokens without losing any guidance
- **Tightened rule prose** - trimmed explanatory text Claude already knows (main-safety rationale, cooperative cancellation basics) while keeping all rules and code patterns intact

Net result: 29 lines removed, 11 added - a smaller, sharper skill file.

</details>

---

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.