### PR TITLE
Add maxRoundTripLatency option

### DIFF
--- a/.changeset/brave-plums-tease.md
+++ b/.changeset/brave-plums-tease.md
@@ -1,5 +1,5 @@
 ---
-"client-sdk-android": patch
+"client-sdk-android": minor
 ---
 
 Allow customizing `maxRoundTripLatency` on `LocalParticipant.performRpc` for high-latency networks

--- a/.changeset/brave-plums-tease.md
+++ b/.changeset/brave-plums-tease.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Allow customizing `maxRoundTripLatency` on `LocalParticipant.performRpc` for high-latency networks

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -25,8 +25,8 @@ livekit-rules:
 exceptions:
   TooGenericExceptionCaught:
     active: false
-    
+
 complexity:
   LongMethod:
     active: true
-    allowedLines: 120
+    threshold: 120

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -25,3 +25,8 @@ livekit-rules:
 exceptions:
   TooGenericExceptionCaught:
     active: false
+    
+complexity:
+  LongMethod:
+    active: true
+    allowedLines: 120

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -1142,8 +1142,8 @@ constructor(
         localParticipant.unregisterRpcMethod(method)
     }
 
-    override suspend fun performRpc(destinationIdentity: Participant.Identity, method: String, payload: String, responseTimeout: Duration): String {
-        return localParticipant.performRpc(destinationIdentity, method, payload, responseTimeout)
+    override suspend fun performRpc(destinationIdentity: Participant.Identity, method: String, payload: String, responseTimeout: Duration, maxRoundTripLatency: Duration): String {
+        return localParticipant.performRpc(destinationIdentity, method, payload, responseTimeout, maxRoundTripLatency)
     }
 
     // ----------------------------------- RTCEngine.Listener ------------------------------------//

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -1100,10 +1100,8 @@ internal constructor(
         method: String,
         payload: String,
         responseTimeout: Duration,
+        maxRoundTripLatency: Duration,
     ): String = coroutineScope {
-        // Maximum amount of time it should ever take for an RPC request to reach the destination, and the ACK to come back
-        // This is set to 7 seconds to account for various relay timeouts and retries in LiveKit Cloud that occur in rare cases
-        val maxRoundTripLatency = 7.seconds
         // Minimum allowed effective timeout to ensure the RPC lifecycle always has at least
         // one second to complete, even after accounting for round-trip latency.
         val minEffectiveTimeout = 1.seconds

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/rpc/RpcManager.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/rpc/RpcManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 LiveKit, Inc.
+ * Copyright 2025-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/rpc/RpcManager.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/rpc/RpcManager.kt
@@ -82,6 +82,10 @@ interface RpcManager {
      *      If a value less than 8s is provided, it will be automatically clamped to 8s
      *      to ensure sufficient time for round-trip latency buffering.
      *      Defaults to 15 seconds.
+     * @param maxRoundTripLatency The maximum amount of time it should ever take for an RPC request to
+     *      reach the destination and for the ACK to come back. Defaults to 7 seconds to account
+     *      for various relay timeouts and retries in LiveKit Cloud that occur in rare cases.
+     *      Most callers should not need to change this.
      * @return The response payload.
      * @throws RpcError on failure. Details in [RpcError.message].
      */
@@ -90,5 +94,6 @@ interface RpcManager {
         method: String,
         payload: String,
         responseTimeout: Duration = 15.seconds,
+        maxRoundTripLatency: Duration = 7.seconds,
     ): String
 }


### PR DESCRIPTION
Exposes a new `maxRoundTripLatency` parameter on `LocalParticipant.performRpc` so that a caller can configure the amount of time they'd like to be able to tolerate between a RPC request being enqueued and a RPCRequest's ACK comes back from the remote participant.

I expect this to be a fairly uncommonly tweaked value, but exposing it means that a client can be configured to tolerate situations where RPC requests are backed up behind other messages due to webrtc head of line blocking on the data channel, and RPC requests are timing out before actually being able to be sent via webrtc.

Related swift change: https://github.com/livekit/client-sdk-swift/pull/1023