### PR TITLE
fix(audio): clear audioSwitch synchronously in AudioSwitchHandler.stop()

### DIFF
--- a/.changeset/audioswitch-stale-switch-on-restart.md
+++ b/.changeset/audioswitch-stale-switch-on-restart.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix audio output getting stuck on the earpiece after reconnecting on a reused `Room` (Android 12+). `AudioSwitchHandler.stop()` now clears its `audioSwitch` reference synchronously (and the field is `@Volatile`) so a subsequent `start()` reliably observes the teardown and re-creates the switch, instead of racing the posted teardown runnable and reusing a stale, already-stopped switch.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/audio/AudioSwitchHandler.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/audio/AudioSwitchHandler.kt
@@ -199,6 +199,9 @@ constructor(private val context: Context) : AudioHandler {
      */
     var forceHandleAudioRouting = false
 
+    // Volatile and nulled synchronously in stop() (rather than only inside the posted
+    // teardown runnable) so that a subsequent start() reliably observes the teardown.
+    @Volatile
     private var audioSwitch: AbstractAudioSwitch? = null
 
     // AudioSwitch is not threadsafe, so all calls should be done through a single thread.
@@ -261,10 +264,17 @@ constructor(private val context: Context) : AudioHandler {
 
     @Synchronized
     override fun stop() {
+        // Null audioSwitch synchronously (under the lock) so a subsequent start() reliably
+        // observes the teardown and re-creates the switch. Previously it was nulled inside the
+        // posted runnable on the handler thread; with handler/thread torn down synchronously
+        // below, a fast start() could read a stale, already-stopped switch and skip re-creation,
+        // leaving audio routing broken (e.g. stuck on the earpiece) until the next connect.
+        // The switch's stop() is still posted, since AbstractAudioSwitch is not threadsafe.
+        val switchToStop = audioSwitch
+        audioSwitch = null
         handler?.removeCallbacksAndMessages(null)
         handler?.postAtFrontOfQueue {
-            audioSwitch?.stop()
-            audioSwitch = null
+            switchToStop?.stop()
         }
         thread?.quitSafely()
 


### PR DESCRIPTION
## Summary

On Android 12+ (the `CommDeviceAudioSwitch` path), audio output can get stuck on the **earpiece** at very low volume after a `disconnect()` + `connect()` on a **reused `Room`** instance (e.g. switching between rooms without releasing/recreating the `Room`). The first connection routes to the speaker correctly; a subsequent reconnect intermittently does not.

## Root cause

A race in `AudioSwitchHandler` between `stop()` and the next `start()`:

- `stop()` nulls `audioSwitch` **inside the posted teardown runnable** (on the handler thread) while tearing down `handler`/`thread` **synchronously**.
- `audioSwitch` is a **non-`@Volatile`** field, and that write happens off the lock on the handler thread.
- A fast subsequent `start()` (a different thread, under the `@Synchronized` lock) can therefore read a **stale, already-stopped** switch and skip re-creation via the `if (audioSwitch == null)` guard.

With no new switch created, `activate()` never re-runs, so the route that the prior `deactivate()` cleared via `clearCommunicationDevice()` (reverting the OS to the earpiece) is never re-asserted.

Instrumented logs from a reproduction (good connect, then a bad reconnect on the same `Room`):

```
# 1st connect — OK (ends on speaker)
start() called. handlerAlive=false, threadAlive=false, audioSwitchNull=true
start(): audioSwitch == null -> creating a new switch
deviceChange: available=[Speakerphone, Earpiece], selected=Speakerphone
switch started+activated (CommDeviceAudioSwitch). selected=Speakerphone

# reconnect on the SAME Room — BAD (stuck on earpiece)
stop() called. audioSwitchNull=false
stop(): posted audioSwitch.stop() + audioSwitch=null on handler thread   # field nulled here
start() called. handlerAlive=false, threadAlive=false, audioSwitchNull=false   # 456ms later, STILL reads non-null
-> SKIPPING re-create (reusing stale, stopped switch)   # no activate(), routing not re-asserted
```

The `audioSwitch = null` write is wall-clock *before* the `start()` read, yet `start()` observes non-null — a memory-visibility issue, compounded by the structural asymmetry that `handler`/`thread` are nulled synchronously while `audioSwitch` is not.

## Fix

Clear `audioSwitch` **synchronously** under the lock in `stop()` (capturing the instance into a local so its `stop()` can still be posted to the handler thread, since `AbstractAudioSwitch` is not threadsafe), and mark the field `@Volatile`. This guarantees the next `start()` observes the teardown and re-creates the switch.

## Verification

With the fix, every reconnect on the reused `Room` logs `start(): audioSwitch == null -> creating a new switch` → `activate()` → `selected=Speakerphone`, and audio reliably routes to the speaker (no more `SKIPPING re-create`). Verified on-device (Android 15, Moto G45 5G) across repeated room switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
