### PR TITLE
feat: add deployment field to agent dispatch

### DIFF
--- a/livekit-android-sdk/src/main/java/io/livekit/android/token/TokenSource.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/token/TokenSource.kt
@@ -35,17 +35,22 @@ data class TokenRequestOptions(
     val participantAttributes: Map<String, String>? = null,
     val agentName: String? = null,
     val agentMetadata: String? = null,
+    /**
+     * Optional deployment to target. Leave empty to target the production deployment.
+     */
+    val agentDeployment: String? = null,
 )
 
 /**
  * Converts a [TokenRequestOptions] to [TokenSourceRequest], a JSON serializable request body.
  */
 fun TokenRequestOptions.toRequest(): TokenSourceRequest {
-    val agents = if (agentName != null || agentMetadata != null) {
+    val agents = if (agentName != null || agentMetadata != null || agentDeployment != null) {
         listOf(
             RoomAgentDispatch(
                 agentName = agentName,
                 metadata = agentMetadata,
+                deployment = agentDeployment,
             ),
         )
     } else {
@@ -105,6 +110,10 @@ data class RoomConfiguration(
 data class RoomAgentDispatch(
     val agentName: String? = null,
     val metadata: String? = null,
+    /**
+     * Optional deployment to target. Leave empty to target the production deployment.
+     */
+    val deployment: String? = null,
 )
 
 @SuppressLint("UnsafeOptInUsageError")


### PR DESCRIPTION
## Summary
- Add `deployment` field to `RoomAgentDispatch` for targeting specific agent deployments
- Add `agentDeployment` to `TokenRequestOptions` to pass deployment through token requests

The `deployment` field allows targeting a specific agent deployment (e.g., "staging"). Leave empty to target the production deployment.

Related PRs:
- node-sdks: https://github.com/livekit/node-sdks/pull/675
- python-sdks: https://github.com/livekit/python-sdks/pull/722
- rust-sdks: https://github.com/livekit/rust-sdks/pull/1176
- client-sdk-swift: https://github.com/livekit/client-sdk-swift/pull/1043
- client-sdk-flutter: https://github.com/livekit/client-sdk-flutter/pull/1111
- client-sdk-js: https://github.com/livekit/client-sdk-js/pull/1971

## Usage
```kotlin
val options = TokenRequestOptions(
    roomName = "my-room",
    agentName = "my-agent",
    agentDeployment = "staging"  // Optional: target specific deployment
)
```

Or directly via `RoomAgentDispatch`:
```kotlin
val dispatch = RoomAgentDispatch(
    agentName = "my-agent",
    metadata = "my-metadata",
    deployment = "staging"
)
```

## Test plan

### Unit Tests
```bash
./gradlew :livekit-android-test:test --tests "*TokenSourceTest*"
./gradlew test
```

### Manual Verification

**1. Verify JSON serialization includes deployment:**
```kotlin
val dispatch = RoomAgentDispatch(
    agentName = "my-agent",
    deployment = "staging"
)
val json = Json.encodeToString(dispatch)
println(json)  // Should include "deployment": "staging"
```

**2. Verify TokenRequestOptions converts to request correctly:**
```kotlin
val options = TokenRequestOptions(
    roomName = "test-room",
    agentName = "my-agent",
    agentDeployment = "staging"
)
val request = options.toRequest()
println(request.roomConfig?.agents?.firstOrNull()?.deployment)  // Should print "staging"
```

**3. Verify JSON round-trip:**
```kotlin
val original = RoomAgentDispatch(
    agentName = "my-agent",
    deployment = "staging"
)
val json = Json.encodeToString(original)
val restored = Json.decodeFromString<RoomAgentDispatch>(json)
assert(restored.deployment == "staging")
```

### End-to-End Verification
1. Use TokenSource to get credentials with agentDeployment set
2. Connect to room - agent with matching deployment should join
3. Verify only staging agent receives the dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)