### PR TITLE
fix(proguard): scope protobuf keep rule to SDK-generated messages

### DIFF
--- a/.changeset/tidy-mangos-scope.md
+++ b/.changeset/tidy-mangos-scope.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Scoped the protobuf consumer keep rule to the SDK's generated messages and the well-known types they embed, instead of every GeneratedMessageLite subclass in the consuming app.

--- a/livekit-android-sdk/consumer-rules.pro
+++ b/livekit-android-sdk/consumer-rules.pro
@@ -42,6 +42,9 @@
 
 # Protobuf
 #########################################
--keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
+-keepclassmembers class livekit.** extends com.google.protobuf.GeneratedMessageLite {
+  <fields>;
+}
+-keepclassmembers class com.google.protobuf.** extends com.google.protobuf.GeneratedMessageLite {
   <fields>;
 }


### PR DESCRIPTION
The protobuf keep rule matched `class * extends GeneratedMessageLite`, so it keeps `<fields>` for every protobuf message in the consuming app, including the app's own protos and unrelated protobuf-using libraries. A consumer rule should only keep what the SDK itself needs.

This scopes it to `livekit.**` for the SDK's generated messages and `com.google.protobuf.**` for the well-known types they embed (`Timestamp` and friends). protobuf-javalite resolves those fields reflectively by name, so both scopes are required.

Tested by deploying an optimized release build of an app that uses the SDK to real devices on Android 13 and Android 17 (latest beta). LiveKit worked as expected with these changes.
