### PR TITLE
Add stopMicrophoneOnMute option to release the microphone while muted

### DIFF
--- a/.changeset/stop-microphone-on-mute.md
+++ b/.changeset/stop-microphone-on-mute.md
@@ -1,0 +1,7 @@
+---
+"client-sdk-android": minor
+---
+
+Add `LocalAudioTrackOptions.stopMicrophoneOnMute`, which stops microphone capture while the audio track is muted. This releases the microphone for other apps and turns off the OS microphone-in-use indicator, without unpublishing the track. Capture restarts automatically on unmute.
+
+Also fix local track publications leaking their jobs on every full reconnect, which left the audio feature collectors of the old publications running and sending feature updates for stale track sids.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -474,14 +474,63 @@ internal constructor(
 
         if (publication != null) {
             val job = scope.launch {
-                track::features.flow.collect {
-                    engine.updateLocalAudioTrack(publication.sid, it + options.getFeaturesList())
+                launch {
+                    track::features.flow.collect {
+                        engine.updateLocalAudioTrack(publication.sid, it + options.getFeaturesList())
+                    }
+                }
+                launch {
+                    // Collection starts with the current value, reconciling on publish and
+                    // whenever applyOptions changes stopMicrophoneOnMute while published.
+                    track::options.flow.collect {
+                        updateAudioRecordingState()
+                    }
                 }
             }
             jobs[publication] = job
         }
 
         return publication != null
+    }
+
+    /**
+     * Tracks whether microphone recording has been stopped through
+     * `PeerConnection.setAudioRecording`, so recording is never touched unless
+     * [LocalAudioTrackOptions.stopMicrophoneOnMute] is in use. Only accessed
+     * from within `withPeerConnection` blocks, which serialize on the RTC thread.
+     */
+    private var audioRecordingStopped = false
+
+    /**
+     * Starts or stops microphone recording to match the current mute state of
+     * the published audio tracks.
+     *
+     * Recording is controlled through the factory-scoped native AudioState, so
+     * the setting survives peer connection recreations, and a republish while
+     * recording is stopped will not reopen the microphone.
+     */
+    internal fun updateAudioRecordingState() {
+        scope.launch {
+            engine.publisher?.withPeerConnection {
+                // Evaluate here so rapid mute toggles converge on the latest state
+                // regardless of coroutine dispatch order.
+                val stopRecording = shouldStopAudioRecording()
+                if (stopRecording != audioRecordingStopped) {
+                    setAudioRecording(!stopRecording)
+                    audioRecordingStopped = stopRecording
+                }
+            }
+        }
+    }
+
+    private fun shouldStopAudioRecording(): Boolean {
+        val audioTracks = localTrackPublications.mapNotNull { publication ->
+            val track = publication.track as? LocalAudioTrack ?: return@mapNotNull null
+            publication to track
+        }
+        return audioTracks.isNotEmpty() &&
+            audioTracks.all { (publication, _) -> publication.muted } &&
+            audioTracks.any { (_, track) -> track.options.stopMicrophoneOnMute }
     }
 
     /**
@@ -971,6 +1020,10 @@ internal constructor(
         if (stopOnUnpublish) {
             track.stop()
         }
+        if (track is LocalAudioTrack) {
+            // Restores microphone recording if it was stopped on account of this track.
+            updateAudioRecordingState()
+        }
         internalListener?.onTrackUnpublished(publication, this)
         eventBus.postEvent(ParticipantEvent.LocalTrackUnpublished(this, publication), scope)
     }
@@ -1276,6 +1329,13 @@ internal constructor(
         // Only set the first time we start a full reconnect.
         if (republishes == null) {
             republishes = pubs
+        }
+
+        // The publications are cleared below, so unpublishTrack can't cancel these
+        // jobs during republishing. Republishing creates fresh jobs for the new
+        // publications.
+        for (publication in pubs) {
+            jobs.remove(publication)?.cancel()
         }
 
         trackPublications = trackPublications.toMutableMap().apply { clear() }

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrackOptions.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalAudioTrackOptions.kt
@@ -24,6 +24,25 @@ data class LocalAudioTrackOptions(
     val autoGainControl: Boolean = true,
     val highPassFilter: Boolean = true,
     val typingNoiseDetection: Boolean = true,
+    /**
+     * Whether to stop microphone capture while this track's publication is muted.
+     *
+     * Stopping capture releases the microphone so other apps can record from it,
+     * and turns off the OS microphone-in-use indicator. Capture automatically
+     * restarts when the publication is unmuted.
+     *
+     * Microphone capture is shared by all local audio tracks, so it is only
+     * stopped while every published local audio track is muted.
+     *
+     * Defaults to false, which keeps the microphone open while muted for
+     * instant unmutes.
+     *
+     * Example:
+     * ```
+     * room.audioTrackCaptureDefaults = room.audioTrackCaptureDefaults.copy(stopMicrophoneOnMute = true)
+     * ```
+     */
+    val stopMicrophoneOnMute: Boolean = false,
 )
 
 internal fun LocalAudioTrackOptions.toAudioProcessingOptions(): AudioProcessingOptions {

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalTrackPublication.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalTrackPublication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 LiveKit, Inc.
+ * Copyright 2023-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ class LocalTrackPublication(
     /**
      * Mute or unmute the current track. Muting the track would stop audio or video from being
      * transmitted to the server, and notify other participants in the room.
+     *
+     * Muting an audio track with [LocalAudioTrackOptions.stopMicrophoneOnMute] enabled also
+     * stops the microphone capture, releasing the microphone while muted.
      */
     override var muted: Boolean
         get() = super.muted
@@ -47,6 +50,10 @@ class LocalTrackPublication(
             val participant = this.participant.get() as? LocalParticipant ?: return
 
             participant.engine.updateMuteStatus(sid, muted)
+
+            if (mediaTrack is LocalAudioTrack) {
+                participant.updateAudioRecordingState()
+            }
 
             if (muted) {
                 participant.onTrackMuted(this)

--- a/livekit-android-test/src/main/java/io/livekit/android/test/mock/MockPeerConnection.kt
+++ b/livekit-android-test/src/main/java/io/livekit/android/test/mock/MockPeerConnection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 LiveKit, Inc.
+ * Copyright 2023-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,14 @@ class MockPeerConnection(
     override fun setAudioPlayout(playout: Boolean) {
     }
 
+    var audioRecording = true
+        private set
+    var setAudioRecordingCallCount = 0
+        private set
+
     override fun setAudioRecording(recording: Boolean) {
+        setAudioRecordingCallCount++
+        audioRecording = recording
     }
 
     override fun setConfiguration(config: RTCConfiguration): Boolean {

--- a/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
@@ -26,6 +26,8 @@ import io.livekit.android.events.RoomEvent
 import io.livekit.android.room.DefaultsManager
 import io.livekit.android.room.RTCEngine
 import io.livekit.android.room.RoomException
+import io.livekit.android.room.track.LocalAudioTrackOptions
+import io.livekit.android.room.track.LocalTrackPublication
 import io.livekit.android.room.track.LocalVideoTrack
 import io.livekit.android.room.track.LocalVideoTrackOptions
 import io.livekit.android.room.track.ScreenSharePresets
@@ -38,6 +40,7 @@ import io.livekit.android.test.MockE2ETest
 import io.livekit.android.test.assert.assertIsClassList
 import io.livekit.android.test.coroutines.toListUntilSignal
 import io.livekit.android.test.events.EventCollector
+import io.livekit.android.test.mock.MockAudioStreamTrack
 import io.livekit.android.test.mock.MockDataChannel
 import io.livekit.android.test.mock.MockEglBase
 import io.livekit.android.test.mock.MockRTCThreadToken
@@ -247,6 +250,114 @@ class LocalParticipantMockE2ETest : MockE2ETest() {
         room.localParticipant.unpublishTrack(videoTrack)
 
         transceivers.forEach { Mockito.verify(it).stopInternal() }
+    }
+
+    @Test
+    fun muteStopsMicrophoneRecordingWhenOptedIn() = runTest {
+        connect()
+        room.localParticipant.publishAudioTrack(
+            track = createMockLocalAudioTrack(options = LocalAudioTrackOptions(stopMicrophoneOnMute = true)),
+        )
+        val publication = room.localParticipant.trackPublications.values.first() as LocalTrackPublication
+        val publisherConnection = getPublisherPeerConnection()
+
+        publication.muted = true
+        assertFalse(publisherConnection.audioRecording)
+
+        publication.muted = false
+        assertTrue(publisherConnection.audioRecording)
+    }
+
+    @Test
+    fun muteKeepsMicrophoneRecordingByDefault() = runTest {
+        connect()
+        room.localParticipant.publishAudioTrack(track = createMockLocalAudioTrack())
+        val publication = room.localParticipant.trackPublications.values.first() as LocalTrackPublication
+
+        publication.muted = true
+        publication.muted = false
+        room.localParticipant.unpublishTrack(publication.track!!)
+
+        val publisherConnection = getPublisherPeerConnection()
+        assertTrue(publisherConnection.audioRecording)
+        assertEquals(0, publisherConnection.setAudioRecordingCallCount)
+    }
+
+    @Test
+    fun microphoneRecordingStopsOnlyWhenAllAudioTracksAreMuted() = runTest {
+        connect()
+        room.localParticipant.publishAudioTrack(
+            track = createMockLocalAudioTrack(options = LocalAudioTrackOptions(stopMicrophoneOnMute = true)),
+        )
+
+        val secondCid = "second_audio_cid"
+        val secondSid = "TR_second_audio"
+        wsFactory.registerSignalRequestHandler { request ->
+            if (request.hasAddTrack() && request.addTrack.cid == secondCid) {
+                wsFactory.receiveMessage(
+                    with(LivekitRtc.SignalResponse.newBuilder()) {
+                        trackPublished = with(LivekitRtc.TrackPublishedResponse.newBuilder()) {
+                            cid = secondCid
+                            track = TestData.LOCAL_AUDIO_TRACK.toBuilder().setSid(secondSid).build()
+                            build()
+                        }
+                        build()
+                    },
+                )
+                true
+            } else {
+                false
+            }
+        }
+        room.localParticipant.publishAudioTrack(
+            track = createMockLocalAudioTrack(mediaTrack = MockAudioStreamTrack(id = secondCid)),
+        )
+
+        val micPublication = room.localParticipant.trackPublications[TestData.LOCAL_AUDIO_TRACK.sid] as LocalTrackPublication
+        val secondPublication = room.localParticipant.trackPublications[secondSid] as LocalTrackPublication
+        val publisherConnection = getPublisherPeerConnection()
+
+        micPublication.muted = true
+        assertTrue(publisherConnection.audioRecording)
+
+        secondPublication.muted = true
+        assertFalse(publisherConnection.audioRecording)
+
+        secondPublication.muted = false
+        assertTrue(publisherConnection.audioRecording)
+    }
+
+    @Test
+    fun applyOptionsWhileMutedUpdatesMicrophoneRecording() = runTest {
+        connect()
+        val audioTrack = createMockLocalAudioTrack()
+        room.localParticipant.publishAudioTrack(track = audioTrack)
+        val publication = room.localParticipant.trackPublications.values.first() as LocalTrackPublication
+        val publisherConnection = getPublisherPeerConnection()
+
+        publication.muted = true
+        assertTrue(publisherConnection.audioRecording)
+
+        assertTrue(audioTrack.applyOptions(audioTrack.options.copy(stopMicrophoneOnMute = true)).isSuccess)
+        assertFalse(publisherConnection.audioRecording)
+
+        assertTrue(audioTrack.applyOptions(audioTrack.options.copy(stopMicrophoneOnMute = false)).isSuccess)
+        assertTrue(publisherConnection.audioRecording)
+    }
+
+    @Test
+    fun unpublishWhileMutedRestoresMicrophoneRecording() = runTest {
+        connect()
+        val audioTrack = createMockLocalAudioTrack(options = LocalAudioTrackOptions(stopMicrophoneOnMute = true))
+        room.localParticipant.publishAudioTrack(track = audioTrack)
+        val publication = room.localParticipant.trackPublications.values.first() as LocalTrackPublication
+        val publisherConnection = getPublisherPeerConnection()
+
+        publication.muted = true
+        assertFalse(publisherConnection.audioRecording)
+
+        room.localParticipant.unpublishTrack(audioTrack)
+        assertTrue(publisherConnection.audioRecording)
     }
 
     @Test


### PR DESCRIPTION
Fixes #375.

Android equivalent of the web SDK's [`stopMicTrackOnMute`](https://github.com/livekit/client-sdk-js/blob/41c19491aeda7c3e1be16d04a8086d2e4276f291/src/room/track/options.ts#L132), added as `LocalAudioTrackOptions.stopMicrophoneOnMute`.

Two reasons to want it:

1. Muting an audio publication only disables the media track locally (`mediaTrack.enabled = false`). The ADM keeps `AudioRecord` open, so the OS microphone-in-use indicator stays lit for as long as the track is published. An indicator burning next to a muted mic is a privacy concern.
2. Advanced call handling needs the device actually released. Putting a call on hold should cleanly hand the microphone back so another app can use it.

Unpublishing and republishing the track does release the mic, but it leaks native memory on the audio path and churns track history on the server.

<details>
<summary>Leak measurements</summary>

Measured on LiveKit Android SDK [2.27.0](https://github.com/livekit/client-sdk-android/releases/tag/v2.27.0), on a Pixel 6a (bluejay) running Android 17 beta (build `CP41.260701.005`, API 37, 2026-07-05 security patch).

On a two-party call with the camera off, toggling the microphone 50 times through unpublish/republish retained about 11.7 MB of native heap, roughly 0.23 MB per cycle, against a baseline noise band of 0.9 MB.

| Metric | Baseline | After 50 cycles, settled | Delta |
|---|---|---|---|
| Native Heap Alloc | 91.7 - 92.5 MB | 103.6 - 104.2 MB | +11.7 MB |
| Native Heap PSS | 83.8 - 84.3 MB | 94.3 - 94.4 MB | +10.4 MB |
| Total PSS | 371.8 - 376.3 MB | 388.3 - 391.0 MB | +15.5 MB |
| Graphics | 88.3 - 89.9 MB | 88.5 - 90.0 MB | unchanged |

Three details point at retention rather than an artifact. There was no decay: five samples over the following 60 seconds read 104.1, 104.2, 103.6, 104.2, 104.2 MB. `Native Heap Size` grew from 125.5 to 134.0 MB, so the arena was extended to satisfy live allocations, which fragmentation slack does not do. `Graphics` is unchanged, so no part of the video pipeline is involved.

The same test driving the camera instead fell back inside its baseline band within 16 seconds, which lines up with #971 fixing the video path by stopping the transceiver and disposing the `VideoSource` on unpublish. The audio path has no counterpart to that fix, and the measured version already contains it.

That split looks deliberate rather than accidental. Reviewing the libwebrtc side in [webrtc-sdk/webrtc#194](https://github.com/webrtc-sdk/webrtc/pull/194#pullrequestreview-3173352546), the transceiver teardown crash is described as "not even reproducible without audio", and the equivalent SDK-side fix then landed for video only, [described](https://github.com/livekit/client-sdk-swift/pull/775) as "restricting to video tracks (where it really matters), due to reproducible crashes in the audio stack". So the audio-side leak is known and was left in place rather than risk the audio path.

</details>

The web SDK's approach has no direct port here, since capture is owned by the ADM shared across the `PeerConnectionFactory` rather than by the track. Muting the publication instead stops capture through `PeerConnection.setAudioRecording(false)`, which flips `recording_enabled_` on the factory-scoped `AudioState` and stops the ADM, releasing `AudioRecord` with no renegotiation and no change to the publication. `AudioState::AddSendingStream` checks the same flag, so a reconnect or republish won't silently reopen the mic while muted. Capture restarts on unmute.

Recording state is reconciled from the current publications on mute changes (including server-initiated ones), publish, unpublish, and `applyOptions` changes while published, with the desired state computed on the RTC thread so rapid toggles converge. Capture is shared by every local audio track, so it is only stopped while all published audio tracks are muted. Apps that don't opt in get no behavior change; a test asserts `setAudioRecording` is never called for them.

Also fixed: `prepareForFullReconnect()` clears the publications, so the `unpublishTrack()` calls in `republishTracks()` could never find and cancel the publication jobs, leaking each old audio publication's feature collector on every full reconnect and leaving it sending feature updates for a stale track sid. The reconciliation added here rides those same jobs, which is how it surfaced. The jobs are now cancelled when preparing for the reconnect.

Tests cover mute/unmute release and restore, zero native calls without opt-in, unpublish while muted, `applyOptions` toggling the flag in both directions while muted, and the all-tracks-muted rule with two simultaneous audio publications.

