### PR TITLE
Fix custom RTCConfigurations not picking up server-provided ice servers when needed

### DIFF
--- a/.changeset/tricky-grapes-compare.md
+++ b/.changeset/tricky-grapes-compare.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix custom RTCConfigurations not picking up server-provided ice servers when user-provided list is empty

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -998,14 +998,13 @@ internal constructor(
 
             // Only use server-provided servers if user doesn't provide any.
             if (mergedServers.isEmpty()) {
-                iceServers.forEach { server ->
-                    if (!mergedServers.contains(server)) {
-                        mergedServers.add(server)
-                    }
-                }
+                mergedServers.addAll(serverIceServers)
             }
 
             iceServers = mergedServers
+            sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
+            continualGatheringPolicy =
+                PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY
         }
             ?: RTCConfiguration(serverIceServers).apply {
                 sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN

--- a/livekit-android-test/src/test/java/io/livekit/android/room/RTCEngineMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/RTCEngineMockE2ETest.kt
@@ -17,6 +17,7 @@
 package io.livekit.android.room
 
 import com.google.protobuf.ByteString
+import io.livekit.android.ConnectOptions
 import io.livekit.android.room.track.TrackException
 import io.livekit.android.test.MockE2ETest
 import io.livekit.android.test.events.FlowCollector
@@ -82,6 +83,38 @@ class RTCEngineMockE2ETest : MockE2ETest() {
         val subPeerConnection = getSubscriberPeerConnection()
 
         assertEquals(sentIceServers, subPeerConnection.rtcConfig.iceServers)
+    }
+
+    @Test
+    fun customRtcConfigWithEmptyIceServersUsesServerIceServers() = runTest {
+        val connectJob = async {
+            room.connect(
+                url = TestData.EXAMPLE_URL,
+                token = "token",
+                options = ConnectOptions(
+                    rtcConfig = PeerConnection.RTCConfiguration(emptyList()).apply {
+                        iceTransportsType = PeerConnection.IceTransportsType.RELAY
+                    },
+                ),
+            )
+        }
+        prepareSignal(TestData.JOIN)
+        connectJob.await()
+        connectPeerConnection()
+
+        val subPeerConnection = getSubscriberPeerConnection()
+        assertEquals(PeerConnection.IceTransportsType.RELAY, subPeerConnection.rtcConfig.iceTransportsType)
+        val sentIceServers = TestData.JOIN.join.iceServersList
+            .map { it.toWebrtc() }
+        assertEquals(sentIceServers, subPeerConnection.rtcConfig.iceServers)
+        assertEquals(
+            PeerConnection.SdpSemantics.UNIFIED_PLAN,
+            subPeerConnection.rtcConfig.sdpSemantics,
+        )
+        assertEquals(
+            PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY,
+            subPeerConnection.rtcConfig.continualGatheringPolicy,
+        )
     }
 
     @Test


### PR DESCRIPTION
A [previous variable name change](https://github.com/livekit/client-sdk-android/commit/d0edb9372da83a4857b72d69912f71c2c90e9440) of an outer variable caused the inner apply scope code to refer to the RTCConfiguration's iceServer list (which was empty in this if branch), and not to the server-provided ice servers.