### PR TITLE
Add publisher initial video bitrate API

### DIFF
--- a/.changeset/bright-bitrates-start.md
+++ b/.changeset/bright-bitrates-start.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": minor
+---
+
+Add `Room.setPublisherInitialVideoBitrate` to configure the publisher PeerConnection's current and maximum video bitrate after connecting.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/RTCEngine.kt
@@ -443,6 +443,26 @@ internal constructor(
         return SenderTransceiverHandle(publisher, transceiver, sessionState)
     }
 
+    /**
+     * Sets the publisher PeerConnection's initial video bitrate.
+     */
+    internal suspend fun setPublisherInitialVideoBitrate(
+        initialBitrateBps: Int,
+        maxBitrateBps: Int,
+    ): Boolean {
+        require(initialBitrateBps > 0)
+        require(maxBitrateBps >= initialBitrateBps)
+
+        val publisherTransport = publisher ?: return false
+        return publisherTransport.withPeerConnection {
+            setBitrate(
+                null,
+                initialBitrateBps,
+                maxBitrateBps,
+            )
+        } == true
+    }
+
     fun updateSubscriptionPermissions(
         allParticipants: Boolean,
         participantTrackPermissions: List<ParticipantTrackPermission>,

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/Room.kt
@@ -1624,6 +1624,31 @@ constructor(
     fun getPublisherRTCStats(callback: RTCStatsCollectorCallback) = engine.getPublisherRTCStats(callback)
 
     /**
+     * Sets the local publisher's initial video bitrate.
+     *
+     * Call this after the room has connected and before or immediately after publishing video.
+     * For example:
+     * ```
+     * room.setPublisherInitialVideoBitrate(
+     *     initialBitrateBps = 1_500_000,
+     *     maxBitrateBps = 3_500_000,
+     * )
+     * ```
+     *
+     * @return `true` when WebRTC accepts the bitrate configuration, otherwise `false`.
+     * @throws IllegalArgumentException if either bitrate is invalid.
+     */
+    suspend fun setPublisherInitialVideoBitrate(
+        initialBitrateBps: Int,
+        maxBitrateBps: Int,
+    ): Boolean {
+        return engine.setPublisherInitialVideoBitrate(
+            initialBitrateBps = initialBitrateBps,
+            maxBitrateBps = maxBitrateBps,
+        )
+    }
+
+    /**
      * Get stats for the subscriber peer connection.
      *
      * @see getPublisherRTCStats

--- a/livekit-android-test/src/main/java/io/livekit/android/test/mock/MockPeerConnection.kt
+++ b/livekit-android-test/src/main/java/io/livekit/android/test/mock/MockPeerConnection.kt
@@ -46,6 +46,7 @@ class MockPeerConnection(
     private var closed = false
     var localDesc: SessionDescription? = null
     var remoteDesc: SessionDescription? = null
+    var lastBitrateSettings: Triple<Int?, Int?, Int?>? = null
 
     private val signalStateMachine = SignalStateMachine { newState ->
         observer?.onSignalingChange(newState)
@@ -210,6 +211,7 @@ class MockPeerConnection(
     }
 
     override fun setBitrate(min: Int?, current: Int?, max: Int?): Boolean {
+        lastBitrateSettings = Triple(min, current, max)
         return true
     }
 

--- a/livekit-android-test/src/test/java/io/livekit/android/room/RTCEngineMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/RTCEngineMockE2ETest.kt
@@ -150,6 +150,22 @@ class RTCEngineMockE2ETest : MockE2ETest() {
     }
 
     @Test
+    fun setPublisherInitialVideoBitrate() = runTest {
+        connect()
+
+        val applied = room.setPublisherInitialVideoBitrate(
+            initialBitrateBps = 1_500_000,
+            maxBitrateBps = 3_500_000,
+        )
+
+        assertTrue(applied)
+        assertEquals(
+            Triple(null, 1_500_000, 3_500_000),
+            getPublisherPeerConnection().lastBitrateSettings,
+        )
+    }
+
+    @Test
     fun iceSubscriberConnect() = runTest {
         connect()
         assertEquals(


### PR DESCRIPTION
## Summary

- add `Room.setPublisherInitialVideoBitrate` for configuring the publisher PeerConnection
- set the WebRTC current and maximum video bitrate through `PeerConnection.setBitrate`
- add regression coverage and release metadata

## Motivation

`VideoEncoding.maxBitrate` only caps the sender encoding bitrate and does not initialize libwebrtc's current target bitrate. This API allows clients to seed the publisher bitrate after connecting, which is particularly useful for H.264 publishing.

## Validation

- `./gradlew :livekit-android-test:testDebugUnitTest --tests io.livekit.android.room.RTCEngineMockE2ETest.setPublisherInitialVideoBitrate`
- `./gradlew spotlessCheck`