### PR TITLE
fix: skip duplicate backup codec publish instead of throwing

### DIFF
--- a/.changeset/idempotent-add-simulcast-track.md
+++ b/.changeset/idempotent-add-simulcast-track.md
@@ -1,0 +1,5 @@
+---
+"client-sdk-android": patch
+---
+
+Fix crash when a duplicate SubscribedQualityUpdate requests a backup codec that is already added. addSimulcastTrack now skips the duplicate instead of throwing IllegalStateException ("VP8 already added!"), matching the JS SDK behavior.

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/LocalParticipant.kt
@@ -1273,7 +1273,10 @@ internal constructor(
             return
         }
         val (newOptions, newEncodings) = result
-        val simulcastTrack = track.addSimulcastTrack(codec, newEncodings)
+        // A duplicate SubscribedQualityUpdate can request a codec that is already being
+        // published (or mid-publish, before the sender is attached). Treat it as a no-op
+        // instead of throwing, so a repeated update doesn't crash the session.
+        val simulcastTrack = track.addSimulcastTrack(codec, newEncodings) ?: return
 
         val transceiverInit = RtpTransceiverInit(
             RtpTransceiver.RtpTransceiverDirection.SEND_ONLY,

--- a/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
+++ b/livekit-android-sdk/src/main/java/io/livekit/android/room/track/LocalVideoTrack.kt
@@ -430,9 +430,10 @@ constructor(
         return newCodecs
     }
 
-    internal fun addSimulcastTrack(codec: VideoCodec, encodings: List<RtpParameters.Encoding>): SimulcastTrackInfo {
+    internal fun addSimulcastTrack(codec: VideoCodec, encodings: List<RtpParameters.Encoding>): SimulcastTrackInfo? {
         if (this.simulcastCodecs.containsKey(codec)) {
-            throw IllegalStateException("$codec already added!")
+            LKLog.w { "$codec already added, skipping." }
+            return null
         }
         val simulcastTrackInfo = SimulcastTrackInfo(
             codec = codec.codecName,

--- a/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
+++ b/livekit-android-test/src/test/java/io/livekit/android/room/participant/LocalParticipantMockE2ETest.kt
@@ -341,6 +341,36 @@ class LocalParticipantMockE2ETest : MockE2ETest() {
     }
 
     @Test
+    fun addSimulcastTrackForAlreadyAddedCodecIsNoOp() = runTest {
+        val videoTrack = createLocalTrack()
+
+        val first = videoTrack.addSimulcastTrack(VideoCodec.VP8, emptyList())
+        val second = videoTrack.addSimulcastTrack(VideoCodec.VP8, emptyList())
+
+        assertNotNull(first)
+        assertNull(second)
+    }
+
+    @Test
+    fun duplicateSubscribedQualityUpdateDoesNotRepublishBackupCodec() = runTest {
+        room.videoTrackPublishDefaults = room.videoTrackPublishDefaults.copy(
+            videoCodec = VideoCodec.VP9.codecName,
+            scalabilityMode = "L3T3",
+            backupCodec = BackupVideoCodec(codec = VideoCodec.VP8.codecName),
+        )
+
+        connect()
+        val videoTrack = createLocalTrack()
+        room.localParticipant.publishVideoTrack(videoTrack)
+
+        val trackSid = room.localParticipant.videoTrackPublications.first().first.sid
+        receiveSubscribedQualityUpdate(trackSid)
+        receiveSubscribedQualityUpdate(trackSid)
+
+        assertEquals(2, getPublisherPeerConnection().transceivers.size)
+    }
+
+    @Test
     fun disposeDisposesVideoSource() {
         val source = mock(VideoSource::class.java)
         val videoTrack = createLocalTrack(source = source)


### PR DESCRIPTION
Fixes #1000

## Problem

When the server sends a `SubscribedQualityUpdate` requesting a backup codec that is already added (or whose publication is still in flight), the SDK crashes the app with:

```
java.lang.IllegalStateException: VP8 already added!
    at io.livekit.android.room.track.LocalVideoTrack.addSimulcastTrack(LocalVideoTrack.kt)
    at io.livekit.android.room.participant.LocalParticipant.handleSubscribedQualityUpdate(LocalParticipant.kt)
    at io.livekit.android.room.RTCEngine.onSubscribedQualityUpdate(RTCEngine.kt)
    at io.livekit.android.room.SignalClient.handleSignalResponseImpl(SignalClient.kt)
```

The exception is thrown on the SDK's internal coroutine dispatcher (`DefaultDispatcher-worker-N`), so there is no way for the application to catch it — it takes down the whole process during a live call.

We hit this in production (self-hosted SFU, publisher on VP9 with the default VP8 backup, `PREFER_REGRESSION`). Repeated identical updates are expected server behavior by design: `MediaTrack.Restart()` (ICE restart / session resume) and `MediaTrack.SetMuted(false)` (unmuting / enabling the camera) both re-emit the current state — `dynacastManager.ForceUpdate()` explicitly skips the "changed" check. A client therefore has to handle a repeated `SubscribedQualityUpdate` idempotently.

## Root cause

There is a window between the two updates in which the codec entry exists but its sender is not yet attached:

1. First update arrives → `setPublishingCodecs` finds no entry for VP8 → returns it as a new codec → `publishAdditionalCodecForTrack` calls `addSimulcastTrack`, which inserts the entry, and then launches a coroutine to create the transceiver. `simulcastTrackInfo.sender` is only assigned inside that coroutine, after the signaling round-trip.
2. Second (identical) update arrives before the sender is attached → `setPublishingCodecs` sees `simulcastInfo?.sender == null` and treats the codec as new again → `addSimulcastTrack` finds the key already present and throws.

The check at `setPublishingCodecs` conflates "never started" with "started, still in flight".

## Fix

Make `addSimulcastTrack` idempotent: if the codec is already present, log a warning and return `null` instead of throwing; `publishAdditionalCodecForTrack` treats `null` as a no-op and returns, so no duplicate transceiver is created and no duplicate `AddTrackRequest` is sent.

This mirrors the JS SDK, where `LocalVideoTrack.addSimulcastTrack` logs and returns `undefined` for an already-added codec and the caller bails out.

Note the dedup is intentionally per track instance (the `simulcastCodecs` map lives on the `LocalVideoTrack`): a track republished after a reconnect is a new track/sid and must still go through backup-codec publication normally. Session-level dedup would break that case.

## Testing

- `addSimulcastTrackForAlreadyAddedCodecIsNoOp` — calling `addSimulcastTrack` twice for the same codec no longer throws; the second call returns `null`.
- `duplicateSubscribedQualityUpdateDoesNotRepublishBackupCodec` — receiving the same `SubscribedQualityUpdate` twice keeps a single backup transceiver (2 transceivers total).
- Full `LocalParticipantMockE2ETest` suite passes.
